### PR TITLE
Feature openresty Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,4 +86,5 @@ ops/cookbooks/vendor
 secrets.json
 secrets.js
 
-openresty/
+.openresty/**
+!.openresty/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -86,5 +86,5 @@ ops/cookbooks/vendor
 secrets.json
 secrets.js
 
-.openresty/**
-!.openresty/README.md
+openresty/**
+!openresty/README.md

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -132,8 +132,11 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provision "shell", inline: <<~SHELL
-    # cp -a /etc/openresty/. /vagrant/openresty
-    # rm -rf /etc/openresty
-    # ln -s /vagrant/openresty /etc/openresty
+    cd /vagrant/openresty
+    shopt -s extglob
+    rm -frv !("README.md")
+    cp -a "/usr/local/openresty/nginx/conf/." /vagrant/openresty
+    rm -rf /usr/local/openresty/nginx/conf/
+    ln -s /vagrant/openresty/ /usr/local/openresty/nginx/conf
   SHELL
 end

--- a/openresty/README.md
+++ b/openresty/README.md
@@ -1,1 +1,9 @@
-`#include sites-enabled/*;`
+The folder will hold a link to the openresty conf file. Nothing in here will be
+tracked, and edits are only valid on you local VM. The contents of this folder
+is also reset during each provision run. Be mind full of that when making
+changes here.
+
+To apply any changes made in this folder, run the following command from outside
+the VM:
+
+`vagrant ssh -c "sudo service openresty restart"`

--- a/openresty/README.md
+++ b/openresty/README.md
@@ -1,0 +1,1 @@
+`#include sites-enabled/*;`


### PR DESCRIPTION
Added the ability to edit the Open Resty config file outside of the VM. The files will be in the `openresty\` directory. These files are none persistent, not tracked by the repo and will be lost every time `vagrant provision` or `vagrant up` is executed.

I am going to remove chef from this repo, and abandon chef and `t42-common` repo at some point. When this happens, the relevant configure files will be tracked in this repos `ops\` folder.