### PR TITLE
Fix HTTP/2 coalescing cross-routing (hassio served from metrics)

### DIFF
--- a/ops/nginx_conf/targetinfo.lua
+++ b/ops/nginx_conf/targetinfo.lua
@@ -13,7 +13,14 @@ print("In targetInfo module")
 
 -- Main function of the module
 function M.get(ngx, domain, targetInfo)
-    if targetInfo then
+    -- Reuse a previously-resolved target ONLY when it was resolved for this
+    -- exact host. HTTP/2 connection coalescing lets a browser serve several
+    -- hostnames that share one wildcard cert (e.g. *.718it.biz) over a single
+    -- connection; the SSL phase (request_domain) resolves and caches the
+    -- connection's first host in ngx.ctx.targetInfo. Without the domain check
+    -- below, every coalesced request on that connection would be handed the
+    -- first host's target -- e.g. hassio.718it.biz served from metrics.718it.biz.
+    if targetInfo and ngx.ctx.targetInfo_domain == domain then
         return targetInfo
     end
 
@@ -68,6 +75,10 @@ function M.get(ngx, domain, targetInfo)
     end
 
     ngx.ctx.targetInfo = res
+    -- Remember which host this target was resolved for, so the reuse guard at
+    -- the top can tell a genuine cache hit from a coalesced request for a
+    -- different host on the same connection.
+    ngx.ctx.targetInfo_domain = domain
     ngx.ctx.toAllow = true
 
     return res


### PR DESCRIPTION
## Problem
Requesting `hassio.718it.biz` served **metrics.718it.biz**'s backend, even though Redis and `/api/host/lookup` were correct.

Root cause is HTTP/2 **connection coalescing**: hosts that share the `*.718it.biz` wildcard cert resolve to the same IP, so the browser reuses one TLS connection for all of them. The SSL `request_domain` phase resolves the connection's first host and stores it in `ngx.ctx.targetInfo`; the unguarded reuse in `targetinfo.lua`:

```lua
if targetInfo then
    return targetInfo    -- not keyed by host!
end
```

then handed that cached target to every coalesced request on the connection.

### Confirmed on prod (debug logging)
```
TI host=hassio.718it.biz ctx_cached=192.168.1.8       (metrics' IP)
TI SHORTCIRCUIT host=hassio.718it.biz served_ip=192.168.1.8
```
All requests were HTTP/2 on one connection, all for hassio, all short-circuited to metrics' IP.

## Fix
Only reuse the cached target when it was resolved for the **same host**, and record that host when resolving:

```lua
if targetInfo and ngx.ctx.targetInfo_domain == domain then
    return targetInfo
end
...
ngx.ctx.targetInfo = res
ngx.ctx.targetInfo_domain = domain
```

A coalesced request for a different host now re-resolves against its actual `Host` header. Same-host requests still short-circuit, so the per-connection optimization is preserved.

## Deploy / verify
1. Deploy the updated `ops/nginx_conf/targetinfo.lua` (this also removes the temporary `TI …` debug lines added during diagnosis).
2. `openresty -s reload` (or `nginx -s reload`).
3. Load `hassio.718it.biz` — it now routes to `192.168.1.27:8123`. With debug logging you'd see `RESOLVED host=hassio.718it.biz ip=192.168.1.27` instead of the metrics short-circuit.

No Lua linter available in this environment; change is a two-line guard, reviewed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)