### PR TITLE
docs: add a Logs (Docker) section

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -89,6 +89,20 @@ lost on container recreation). For cert persistence, enable Redis persistence
 in `docker-entrypoint.sh` or mount a redis AOF/RDB volume. Port 80 is required
 for HTTP-01 challenges (mapped in the compose).
 
+### Logs
+
+OpenResty runs in the foreground and the Node app in the background, both
+writing to the container's stdout/stderr. nginx access/error logs go to files
+(`/var/log/nginx`, on the `proxy-logs` volume), so they do **not** appear in
+`docker logs`.
+
+```bash
+docker compose logs -f proxy                       # app + OpenResty (stdout/stderr)
+docker compose exec proxy tail -f /var/log/nginx/error.log   # nginx errors
+docker compose exec proxy tail -f /var/log/nginx/access.log  # nginx access
+docker compose logs --tail=200 --since=10m proxy    # recent context
+```
+
 ---
 
 ## Method 2: Bare metal (Debian/Ubuntu)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,27 @@ This installer will:
 - Configure systemd service
 - Start the proxy service
 
+## Logs (Docker)
+
+The all-in-one image runs OpenResty in the foreground and the Node app in the
+background, both writing to the container's stdout/stderr. The proxy's nginx
+access/error logs go to files (`/var/log/nginx`, on the `proxy-logs` volume),
+so they do **not** show up in `docker logs`.
+
+```bash
+# App + OpenResty (stdout/stderr)
+docker compose logs -f proxy
+# or, by container name:
+docker logs -f proxy
+
+# nginx access / error logs (in-container files, not in docker logs)
+docker compose exec proxy tail -f /var/log/nginx/access.log
+docker compose exec proxy tail -f /var/log/nginx/error.log
+
+# Recent context
+docker compose logs --tail=200 --since=10m proxy
+```
+
 ## Manual Installation
 
 For manual installation or other distributions, see the detailed steps below.


### PR DESCRIPTION
## What

Adds a **Logs (Docker)** section so it's clear how to get logs when running the all-in-one image.

## Files

- **`README.md`** — new `## Logs (Docker)` section after Quick Install.
- **`DEPLOYMENT.md`** — new `### Logs` subsection under *Method 1: Docker (all-in-one)*.

## Contents

Both cover the same, accurate log routing:
- `docker compose logs -f proxy` (and `docker logs -f proxy` by container name) for the app + OpenResty stdout/stderr.
- The nginx access/error logs go to files (`/var/log/nginx`, on the `proxy-logs` volume) and do **not** appear in `docker logs` — documented as `docker compose exec proxy tail -f /var/log/nginx/{access,error}.log`.
- A `--tail=200 --since=10m` recent-context example.

Verified against the image: OpenResty is exec'd in the foreground (stdout/stderr → docker logs), nginx writes to `/var/log/nginx` (per the `proxy-logs` volume + Dockerfile note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)