### PR TITLE
Fix api-tokens date display + quiet authIO no-token log

### DIFF
--- a/nodejs/middleware/auth.js
+++ b/nodejs/middleware/auth.js
@@ -37,7 +37,12 @@ async function auth(req, res, next){
 
 async function authIO(socket, next){
 	try{
-		let token = await Auth.checkToken(socket.handshake.auth.token || 0);
+		// No token in the handshake (e.g. a page hit before login, or a socket
+		// opened while logged out) → reject the socket cleanly without doing an
+		// AuthToken.get(0) lookup that throws a noisy EntryNotFound trace.
+		let tok = socket.handshake.auth && socket.handshake.auth.token;
+		if(!tok) return next(Auth.errors.login());
+		let token = await Auth.checkToken(tok);
 		socket.user = token.user;
 		next();
 	}catch(error){

--- a/nodejs/models/dns_provider.js
+++ b/nodejs/models/dns_provider.js
@@ -200,7 +200,6 @@ class DnsProvider extends Table{
 				...(domain.zoneId !== undefined ? {zoneId: domain.zoneId} : {}),
 			});
 		}
-		console.log('currentDomains:', currentDomains)
 
 		for(let domain of currentDomains){
 			if(!domain) continue

--- a/nodejs/views/api_tokens.ejs
+++ b/nodejs/views/api_tokens.ejs
@@ -43,13 +43,21 @@
 	}
 
 	function fmtTime(ms){
-		if(!ms) return '—';
-		return moment(new Date(ms)).fromNow() + ' <span class="text-muted">(' + moment(new Date(ms)).format('YYYY-MM-DD HH:mm') + ')</span>';
+		// created_on/last_used_on come back from Redis as strings (model-redis
+		// only coerces fields with an explicit `type`); moment(value, "x") parses
+		// a numeric string-or-number as a Unix-ms timestamp, unlike new Date(str).
+		if(!ms || Number(ms) === 0) return '—';
+		var t = moment(ms, "x");
+		if(!t.isValid()) return '—';
+		return t.fromNow() + ' <span class="text-muted">(' + t.format('YYYY-MM-DD HH:mm') + ')</span>';
 	}
 	function fmtExpiry(token){
-		if(!token.expires_at) return '<span class="badge text-bg-secondary">never</span>';
-		if(token.isExpired) return '<span class="badge text-bg-danger">expired</span>';
-		return '<span class="badge text-bg-warning text-dark">' + moment(new Date(token.expires_at)).fromNow() + '</span>';
+		// expires_at is type:number (a real number); isExpired is a class getter
+		// that is NOT serialized to the client, so compute expiry here.
+		var exp = Number(token.expires_at);
+		if(!exp) return '<span class="badge text-bg-secondary">never</span>';
+		if(Date.now() > exp) return '<span class="badge text-bg-danger">expired</span>';
+		return '<span class="badge text-bg-warning text-dark">' + moment(exp, "x").fromNow() + '</span>';
 	}
 
 	function processToken(token){


### PR DESCRIPTION
Follow-up to #119 (self-service API tokens). Three small fixes found while
testing the API Tokens page:

## 1. "Created: Invalid date (Invalid date)" — date display bug
`created_on`/`last_used_on` have no `type` in `_keyMap`, so model-redis returns
them as **strings** (`"1689200000000"`). `new Date("1689200000000")` is
`Invalid Date`, so every token card showed "Invalid date". Switch to
`moment(ms, "x")` — the `hosts.ejs` / `dns.ejs` precedent — which parses a
numeric string-or-number as a Unix-ms timestamp.

## 2. "expired" badge never showed
`isExpired` is a class **getter**, not serialized to the client JSON by
`toJSON`/`res.json`, so `token.isExpired` was always `undefined` on the client.
Compute expiry in the view: `Date.now() > Number(expires_at)`. Also guard the
`last_used_on: 0` case — string `"0"` is truthy, so it would have rendered
"1970" instead of "—".

## 3. `check error EntryNotFound: AuthToken:0 does not exists` (pre-existing)
`authIO` did `checkToken(socket.handshake.auth.token || 0)`, so any socket.io
connect without a handshake token (login page, pre-login hits) ran
`AuthToken.get(0)` and logged a noisy `EntryNotFound` stack. Guard: reject the
socket with a generic 401 when there's no token. Behavior-preserving —
unauthenticated sockets were already rejected; this just skips the pointless
Redis lookup and the misleading 404 trace. Predates the PAT work.

### Drive-by
Drop a stray `console.log('currentDomains:', ...)` debug line in
`dns_provider.js#updateDomains` (unrelated; surfaced in the same logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)