### PR TITLE
install.sh: support Debian 13 (trixie) OpenResty repo

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -62,13 +62,34 @@ npm --version
 
 ### Step 3: Install OpenResty
 
+openresty.org ships distinct trees for Debian and Ubuntu — use `/package/debian`
+on Debian and `/package/ubuntu` on Ubuntu (using the Ubuntu tree with a Debian
+codename worked on older Debian by coincidence; trixie lives under `/debian`).
+
 ```bash
+# Debian:  OR_PATH=package/debian    Ubuntu/Mint:  OR_PATH=package/ubuntu
+. /etc/os-release
+case "$ID" in debian) OR_PATH=package/debian;; *) OR_PATH=package/ubuntu;; esac
+
 wget -O - https://openresty.org/package/pubkey.gpg | \
   sudo gpg --dearmor -o /usr/share/keyrings/openresty.gpg
 
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openresty.gpg] http://openresty.org/package/ubuntu $(lsb_release -sc) main" | \
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openresty.gpg] http://openresty.org/${OR_PATH} $(lsb_release -sc) main" | \
   sudo tee /etc/apt/sources.list.d/openresty.list
+```
 
+> **Debian 13 (trixie):** apt's sequoia GPG backend rejects SHA-1 signatures by
+> default, and the OpenResty signing key is still SHA-1, so `apt update` will
+> refuse the repo. Extend the SHA-1 acceptance window before updating:
+> ```bash
+> sudo mkdir -p /etc/crypto-policies/back-ends
+> sudo cp /usr/share/apt/default-sequoia.config /etc/crypto-policies/back-ends/apt-sequoia.config
+> sudo sed -i 's/2026-02-01/2028-02-01/' /etc/crypto-policies/back-ends/apt-sequoia.config
+> ```
+> (The `default-sequoia.config` file only ships on Debian 13+, so this is a no-op
+> on older releases. `ops/install.sh` applies this automatically.)
+
+```bash
 apt update && apt install openresty -y
 ```
 

--- a/ops/install.sh
+++ b/ops/install.sh
@@ -48,10 +48,36 @@ echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.co
 	> /etc/apt/sources.list.d/nodesource.list
 
 echo "==> OpenResty apt source"
+# openresty.org ships distinct trees for Debian vs Ubuntu; pick by distro ID.
+# (Using the ubuntu tree with a Debian codename worked on older Debian by
+# coincidence — trixie lives under /debian, so be explicit.)
+. /etc/os-release 2>/dev/null || true
+case "${ID:-}" in
+	debian) OR_REPO_PATH="package/debian" ;;
+	*)      OR_REPO_PATH="package/ubuntu" ;;   # ubuntu, mint, etc.
+esac
+install -d -m 0755 /usr/share/keyrings
 wget -qO- https://openresty.org/package/pubkey.gpg \
 	| gpg --dearmor --yes -o /usr/share/keyrings/openresty.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openresty.gpg] http://openresty.org/package/ubuntu $(lsb_release -sc) main" \
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openresty.gpg] http://openresty.org/${OR_REPO_PATH} $(lsb_release -sc) main" \
 	> /etc/apt/sources.list.d/openresty.list
+
+# Debian 13 (trixie) tightened apt's sequoia GPG backend to reject SHA-1
+# signatures, but the OpenResty repo signing key is still SHA-1 — so the next
+# apt-get update would refuse the repo ("unsignable" / weak digest). Extend
+# the SHA-1 acceptance window via a back-end override. The source config only
+# ships on Debian 13+, so this is a no-op on older Debian / Ubuntu. Idempotent:
+# re-runs re-copy the default and re-extend it.
+if [ -f /usr/share/apt/default-sequoia.config ]; then
+	install -d -m 0755 /etc/crypto-policies/back-ends
+	cp -f /usr/share/apt/default-sequoia.config /etc/crypto-policies/back-ends/apt-sequoia.config
+	sed -i 's/2026-02-01/2028-02-01/' /etc/crypto-policies/back-ends/apt-sequoia.config
+	if grep -q '2028-02-01' /etc/crypto-policies/back-ends/apt-sequoia.config; then
+		echo "    extended apt sequoia SHA-1 acceptance to 2028 (OpenResty key is SHA-1)"
+	else
+		echo "    WARNING: sequoia override did not apply (config date string changed?) — apt update may reject the OpenResty repo" >&2
+	fi
+fi
 
 echo "==> Install Node.js + OpenResty"
 apt-get update


### PR DESCRIPTION
The bare-metal `ops/install.sh` fails on Debian 13 (Trixie) for two reasons:

## 1. SHA-1 repo key rejected
Debian 13 tightened apt's sequoia GPG backend to reject SHA-1 signatures, but
the OpenResty repo signing key is still SHA-1 — so `apt-get update` refuses the
repo (weak digest / unsignable). When `/usr/share/apt/default-sequoia.config`
is present (Debian 13+ only), install a back-end override that extends the
SHA-1 acceptance window to 2028:

```bash
sudo cp /usr/share/apt/default-sequoia.config /etc/crypto-policies/back-ends/apt-sequoia.config
sudo sed -i 's/2026-02-01/2028-02-01/' /etc/crypto-policies/back-ends/apt-sequoia.config
```

No-op on older Debian/Ubuntu (the source file isn't there). Idempotent on
re-run. Verified the override applies (grep for `2028-02-01`); warns if the
upstream date string changes and the sed no-ops.

> Revisit before 2028 — the OpenResty key is expected to rotate to a stronger
> algorithm; drop the override once it does.

## 2. Repo path hardcoded to /package/ubuntu
`http://openresty.org/package/ubuntu <codename>` worked on older Debian by
coincidence, but trixie lives under `/package/debian`. Pick the tree by distro
ID from `/etc/os-release`: `debian` → `/package/debian`, else (ubuntu/mint/…)
→ `/package/ubuntu`.

## Docs
`docs/installation.md` manual steps updated to match, with a note that
`install.sh` applies the sequoia override automatically.

Verified: `bash -n ops/install.sh` clean; OS-detection dry-run picks the right
path (`ID=debian` → `package/debian`, `ID=linuxmint` → `package/ubuntu`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)