### PR TITLE
install.sh: OpenResty repo distro/component fix for Debian

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -62,19 +62,33 @@ npm --version
 
 ### Step 3: Install OpenResty
 
-openresty.org ships distinct trees for Debian and Ubuntu — use `/package/debian`
-on Debian and `/package/ubuntu` on Ubuntu (using the Ubuntu tree with a Debian
-codename worked on older Debian by coincidence; trixie lives under `/debian`).
+openresty.org ships distinct trees (and components) for Debian and Ubuntu. The
+Debian tree is published only up to **bookworm** (there is no trixie block) and
+uses the **`openresty`** component; Ubuntu uses the host codename and **`main`**.
+So on a Debian 13 (trixie) host, point at the `bookworm` distribution (binary-
+compatible, same OpenSSL 3 era).
 
 ```bash
-# Debian:  OR_PATH=package/debian    Ubuntu/Mint:  OR_PATH=package/ubuntu
 . /etc/os-release
-case "$ID" in debian) OR_PATH=package/debian;; *) OR_PATH=package/ubuntu;; esac
+CODENAME="$(lsb_release -sc)"
+case "$ID" in
+  debian)
+    OR_PATH=package/debian
+    OR_COMPONENT=openresty
+    # Debian tree only publishes up to bookworm; fall back to it for trixie+.
+    case "$CODENAME" in jessie|stretch|buster|bullseye|bookworm) OR_DISTRO="$CODENAME";; *) OR_DISTRO=bookworm;; esac
+    ;;
+  *)
+    OR_PATH=package/ubuntu
+    OR_DISTRO="$CODENAME"
+    OR_COMPONENT=main
+    ;;
+esac
 
 wget -O - https://openresty.org/package/pubkey.gpg | \
   sudo gpg --dearmor -o /usr/share/keyrings/openresty.gpg
 
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openresty.gpg] http://openresty.org/${OR_PATH} $(lsb_release -sc) main" | \
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openresty.gpg] http://openresty.org/${OR_PATH} ${OR_DISTRO} ${OR_COMPONENT}" | \
   sudo tee /etc/apt/sources.list.d/openresty.list
 ```
 

--- a/ops/install.sh
+++ b/ops/install.sh
@@ -48,18 +48,32 @@ echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.co
 	> /etc/apt/sources.list.d/nodesource.list
 
 echo "==> OpenResty apt source"
-# openresty.org ships distinct trees for Debian vs Ubuntu; pick by distro ID.
-# (Using the ubuntu tree with a Debian codename worked on older Debian by
-# coincidence — trixie lives under /debian, so be explicit.)
+# openresty.org ships distinct trees (and components) for Debian vs Ubuntu.
+# Debian tree: component "openresty", published only up to "bookworm" (no
+# trixie block) — so on a newer Debian host use the host codename when it's
+# published, else fall back to bookworm (binary-compatible with trixie, same
+# OpenSSL 3 era). Ubuntu tree: component "main", use the host codename.
 . /etc/os-release 2>/dev/null || true
+CODENAME="$(lsb_release -sc 2>/dev/null || echo "")"
 case "${ID:-}" in
-	debian) OR_REPO_PATH="package/debian" ;;
-	*)      OR_REPO_PATH="package/ubuntu" ;;   # ubuntu, mint, etc.
+	debian)
+		OR_REPO_PATH="package/debian"
+		OR_COMPONENT="openresty"
+		case "$CODENAME" in
+			jessie|stretch|buster|bullseye|bookworm) OR_DISTRO="$CODENAME" ;;
+			*)                                        OR_DISTRO="bookworm" ;;
+		esac
+		;;
+	*)
+		OR_REPO_PATH="package/ubuntu"
+		OR_DISTRO="$CODENAME"
+		OR_COMPONENT="main"
+		;;
 esac
 install -d -m 0755 /usr/share/keyrings
 wget -qO- https://openresty.org/package/pubkey.gpg \
 	| gpg --dearmor --yes -o /usr/share/keyrings/openresty.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openresty.gpg] http://openresty.org/${OR_REPO_PATH} $(lsb_release -sc) main" \
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openresty.gpg] http://openresty.org/${OR_REPO_PATH} ${OR_DISTRO} ${OR_COMPONENT}" \
 	> /etc/apt/sources.list.d/openresty.list
 
 # Debian 13 (trixie) tightened apt's sequoia GPG backend to reject SHA-1


### PR DESCRIPTION
Follow-up to #121. The repo line it added still used the live codename +
`main`, but the actual openresty.org layout is:

- **Debian tree** (`/package/debian`): published only up to **bookworm** — there
  is **no trixie** block — and the component is **`openresty`**, not `main`.
- **Ubuntu tree** (`/package/ubuntu`): host codename (noble/jammy/…), component
  **`main`**.

Verified directly against the repo:
```
/package/debian/dists/  -> bookworm bullseye buster jessie stretch   (no trixie)
bookworm Release        -> Components: openresty
/package/ubuntu/dists/  -> noble jammy focal ...                     Components: main
```

## Fix
- **Debian:** distro = the host codename when it's published
  (`jessie|stretch|buster|bullseye|bookworm`), else fall back to **bookworm**
  (binary-compatible with trixie, same OpenSSL 3 era); component **`openresty`**.
- **Ubuntu/Mint:** unchanged — host codename + `main`.

On a trixie host this now produces the working line:
```
deb [arch=amd64 signed-by=/usr/share/keyrings/openresty.gpg] http://openresty.org/package/debian bookworm openresty
```

`docs/installation.md` manual steps updated to match.

Verified: `bash -n` clean; dry-run across `debian:trixie|bookworm|bullseye`,
`ubuntu:noble`, `linuxmint:zena` all produce correct URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)