### PR TITLE
Allow single-label hostnames as a Host target

### DIFF
--- a/nodejs/public/lib/js/val.js
+++ b/nodejs/public/lib/js/val.js
@@ -98,7 +98,9 @@
 // incoming host may be a wildcard ("*.example.com"); the target may not.
 (function(){
 	var LABEL = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
-	var HOSTNAME = /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/i;
+	// Either one bare label (Docker service names, /etc/hosts entries) or a
+	// dotted hostname with an alphabetic TLD.
+	var HOSTNAME = /^(?=.{1,253}$)(?:(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}|[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)$/i;
 	var FORBIDDEN = /[\s/:]/;
 
 	function isIPv4( value ) {

--- a/nodejs/test/unit/hostname_validate.test.js
+++ b/nodejs/test/unit/hostname_validate.test.js
@@ -32,8 +32,12 @@ describe('isValidHostname (strict, for target)', () => {
 		assert.ok(isValidHostname('example.com'));
 		assert.ok(isValidHostname('app.internal.net'));
 	});
-	test('rejects bare labels, numeric TLDs, wildcards', () => {
-		assert.ok(!isValidHostname('localhost'));
+	test('accepts a bare single-label hostname (Docker service names, /etc/hosts)', () => {
+		assert.ok(isValidHostname('localhost'));
+		assert.ok(isValidHostname('sso-manager'));
+		assert.ok(isValidHostname('redis'));
+	});
+	test('rejects numeric-looking targets, wildcards', () => {
 		assert.ok(!isValidHostname('10.10.10.10'));
 		assert.ok(!isValidHostname('*.example.com'));
 		assert.ok(!isValidHostname(''));
@@ -80,6 +84,9 @@ describe('isValidTargetField (target: hostname or IP, no wildcard)', () => {
 	test('accepts hostnames and IPv4', () => {
 		assert.ok(isValidTargetField('app.internal.net'));
 		assert.ok(isValidTargetField('10.0.0.5'));
+	});
+	test('accepts a bare single-label hostname (e.g. a Docker Compose service name)', () => {
+		assert.ok(isValidTargetField('sso-manager'));
 	});
 	test('rejects wildcards, protocol, port, path', () => {
 		assert.ok(!isValidTargetField('*.example.com'));

--- a/nodejs/utils/hostname_validate.js
+++ b/nodejs/utils/hostname_validate.js
@@ -13,8 +13,11 @@
  *                      e.g. "*.example.com", "**.mysite.com", "payments.**", and
  *                      a bare "**" as a global catch-all. (Matched by
  *                      Host.lookUp in models/host.js.)
- *   ip (target)      — a concrete destination: an IPv4 address or a strict
- *                      hostname (dotted, alphabetic TLD). No wildcards.
+ *   ip (target)      — a concrete destination: an IPv4 address, a single
+ *                      unqualified label (e.g. "sso-manager" — a Docker
+ *                      Compose service name, or any other host resolvable
+ *                      via /etc/hosts or a search domain), or a dotted
+ *                      hostname with an alphabetic TLD. No wildcards.
  *
  * Pure (no I/O) so it can be unit tested and reused. Enforced at the route layer
  * (routes/host.js) so internally-created entries (wildcard children, on-demand
@@ -23,8 +26,9 @@
 
 // A single DNS label.
 const LABEL = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
-// A strict hostname: dotted labels + alphabetic TLD (for the target).
-const HOSTNAME = /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/i;
+// A strict hostname: either one bare label (Docker service names, /etc/hosts
+// entries, search-domain-relative names) or dotted labels + alphabetic TLD.
+const HOSTNAME = /^(?=.{1,253}$)(?:(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}|[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)$/i;
 // Scheme, path, port, or whitespace — anything that means it isn't a bare host.
 const FORBIDDEN = /[\s/:]/;
 

--- a/nodejs/views/hosts.ejs
+++ b/nodejs/views/hosts.ejs
@@ -489,7 +489,7 @@
 
 							<div class="form-group">
 								<label for="ip" class="form-label">Target IP or host name</label>
-								<input type="text" name="ip" class="form-control" placeholder="ex: 10.10.10.10 or app.internal.net" validate="target:3" />
+								<input type="text" name="ip" class="form-control" placeholder="ex: 10.10.10.10, app.internal.net, or sso-manager" validate="target:3" />
 								<b class="invalid-feedback"></b>
 								<small class="field-help text-muted d-block">Where matching requests are proxied. Hostname or IP only &mdash; no protocol, port, or path.</small>
 							</div>


### PR DESCRIPTION
## Summary

The `target` (`ip` field) validator required at least two dot-separated
labels, rejecting legitimate single-label hostnames — Docker Compose service
names (`sso-manager`), `/etc/hosts` entries, or anything resolved via a
search domain. Enforced identically client-side (`public/lib/js/val.js`) and
server-side (`utils/hostname_validate.js` → `routes/host.js`), so there was
no way to actually set one through the UI or the API.

This wasn't just a missed case — there's an existing test that explicitly
asserted `isValidHostname('localhost') === false`, so it was a deliberate
original design choice. But it directly conflicts with a real need:
theta-env's `setup.sh` registers the SSO's Docker service name
(`sso-manager`) as a Host target, and that only works today because it goes
through the `Host` model directly, bypassing this validation entirely — the
same thing would be rejected if done through the UI or the management API.

## Change

Relaxes `HOSTNAME` in both `utils/hostname_validate.js` and
`public/lib/js/val.js` (kept in sync per the existing comment) to accept
either a bare single label or the existing dotted-FQDN pattern. Updates the
`ip` field placeholder in `hosts.ejs` to include an example. Flips the one
test that codified the old behavior and adds coverage for the reported case
and for `isValidTargetField`.

## Test plan
- [x] `npm test` — 186/186 pass
- [x] Verified the new regex directly: accepts `sso-manager`, `example.com`,
      `app.internal.net`; still rejects `10.10.10.10` (goes through the IPv4
      path instead), `*.example.com`, `-bad`

🤖 Generated with [Claude Code](https://claude.com/claude-code)