### PR TITLE
Fix DuckDNS double-suffixing a subdomain that already includes .duckdns.org

### DIFF
--- a/nodejs/models/dns_provider/duckdns.js
+++ b/nodejs/models/dns_provider/duckdns.js
@@ -54,6 +54,18 @@ class DuckDns extends DnsApi{
 		if(status !== 'OK') throw this.errors.unauthorized();
 	}
 
+	// Accepts either the bare label ("myhost") or the full duckdns.org name
+	// ("myhost.duckdns.org", how DuckDNS's own site displays it, and what
+	// operators naturally paste in) — strip a trailing ".duckdns.org" so
+	// both forms end up as the same label. Without this, "myhost.duckdns.org"
+	// would get double-suffixed to "myhost.duckdns.org.duckdns.org", which
+	// tld-extract (not aware duckdns.org is a shared suffix) then misparses
+	// as domain "duckdns.org" — surfacing as a confusing "Domain:duckdns.org
+	// does not exists" error two layers away from the actual cause.
+	__normalizeLabel(value){
+		return value.replace(/\.duckdns\.org$/i, '').toLowerCase();
+	}
+
 	// No API to enumerate owned subdomains, so the operator supplies them.
 	// This call both validates the token and, as a side effect, syncs each
 	// domain's A/AAAA record to this host's current public IP if the token
@@ -61,14 +73,14 @@ class DuckDns extends DnsApi{
 	// — the same thing an operator would need to do anyway when pointing a
 	// fresh DuckDNS domain at this proxy.
 	async listDomains(){
-		let labels = this.subdomains.split(',').map(d => d.trim()).filter(Boolean);
+		let labels = this.subdomains.split(',').map(d => this.__normalizeLabel(d.trim())).filter(Boolean);
 		await this.update(labels.join(','), {});
 
 		return labels.map(label => ({domain: `${label}.duckdns.org`}));
 	}
 
 	__label(domain){
-		return domain.domain.replace(/\.duckdns\.org$/, '');
+		return domain.domain.replace(/\.duckdns\.org$/i, '');
 	}
 
 	// No read API exists; public DNS is the only source of truth available.

--- a/nodejs/test/integration/dns_provider.test.js
+++ b/nodejs/test/integration/dns_provider.test.js
@@ -200,6 +200,25 @@ describe('DNS Provider Contract Compliance', () => {
 			const instance = new DuckDns({token: 'mock-token', subdomains: 'mockhost'});
 			assert.strictEqual(instance.__label({domain: 'mockhost.duckdns.org'}), 'mockhost');
 		});
+
+		test('__normalizeLabel accepts both the bare label and the full duckdns.org name', () => {
+			const instance = new DuckDns({token: 'mock-token', subdomains: 'mockhost'});
+			assert.strictEqual(instance.__normalizeLabel('mockhost'), 'mockhost');
+			assert.strictEqual(instance.__normalizeLabel('mockhost.duckdns.org'), 'mockhost');
+			assert.strictEqual(instance.__normalizeLabel('MockHost.DuckDNS.org'), 'mockhost');
+		});
+
+		test('listDomains does not double-suffix a subdomains value that already includes .duckdns.org', async () => {
+			const instance = new DuckDns({token: 'mock-token', subdomains: 'nl-theta42.duckdns.org,other'});
+			// Stub out the network call — this test is only about what domain
+			// name(s) listDomains() builds from `subdomains`, not the live API.
+			instance.update = async () => {};
+			const domains = await instance.listDomains();
+			assert.deepStrictEqual(domains, [
+				{domain: 'nl-theta42.duckdns.org'},
+				{domain: 'other.duckdns.org'},
+			]);
+		});
 	});
 });
 


### PR DESCRIPTION
## Bug

Reported when adding a DuckDNS provider with the full name (as DuckDNS's own
site displays it), e.g. `subdomains: "nl-theta42.duckdns.org"`:

```
curl 'http://.../api/dns/' --data-raw '{"name":"prod","dnsProvider":"DuckDns","token":"...","subdomains":"nl-theta42.duckdns.org"}'

{"name": "EntryNotFound", "message": "Domain:duckdns.org does not exists"}
```

## Root cause

`listDomains()` blindly appended `.duckdns.org` to whatever was entered:

```js
return labels.map(label => ({domain: `${label}.duckdns.org`}));
```

For `subdomains: "nl-theta42.duckdns.org"`, this produced the domain
`nl-theta42.duckdns.org.duckdns.org`. `tld-extract` doesn't know
`duckdns.org` is a shared/private suffix (confirmed separately — it treats
it as an ordinary two-label TLD+1), so it parsed that malformed string down
to domain `duckdns.org`, sub `nl-theta42.duckdns.org`. That normalized
`domain` value then failed an internal existence lookup in `Domain.create`,
surfacing as `EntryNotFound: Domain:duckdns.org does not exists` — a
confusing error two layers away from the actual cause.

## Fix

Add `__normalizeLabel()` to strip a trailing `.duckdns.org` (case-insensitive)
and lowercase the result, applied before building the label list in
`listDomains()`. Both `myhost` and `myhost.duckdns.org` now produce the same,
correct result. Also made `__label()`'s existing suffix-strip
case-insensitive to match.

## Test plan
- [x] New test confirms `listDomains()` builds the right domain names from a
      mix of bare and full-suffix entries (`nl-theta42.duckdns.org,other` →
      `nl-theta42.duckdns.org`, `other.duckdns.org`)
- [x] Verified the new test fails against the pre-fix code (temporarily
      reverted locally) and passes after
- [x] `npm test` — 192/192 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)