### PR TITLE
DnsProvider.create: fix Domain key mismatch and roll back on failure

### DIFF
--- a/nodejs/models/dns_provider.js
+++ b/nodejs/models/dns_provider.js
@@ -29,12 +29,35 @@ class Domain extends Table{
 		'zoneId': {isRequired: false, type: 'string'},
 	}
 
+	// Try the exact string first — Domain.create() stores records under the
+	// literal domain it's given (see model-redis' Table.create, which HSETs
+	// under data[this._key] verbatim), and its own final `this.get(...)` to
+	// return the created instance must find that same literal key. Falling
+	// straight to tldExtract normalization here breaks that for any domain
+	// tldExtract doesn't recognize as a shared/public suffix — e.g. a DuckDNS
+	// name like "myhost.duckdns.org" normalizes to "duckdns.org" (tldExtract
+	// has no idea duckdns.org is shared across many independent registrants),
+	// so create() would always throw EntryNotFound on its own read-back
+	// despite the record having just been written successfully.
+	// Only fall back to the normalized parent domain if no exact record
+	// exists — that's what lets callers look up an arbitrary hostname (e.g.
+	// "www.example.com") and find the Domain that governs it (example.com).
 	static async get(domain, ...args){
 		try{
-			domain = tldExtract(domain).domain;
-		}catch{}
+			return await super.get(domain, ...args);
+		}catch(error){
+			if(error.name !== 'EntryNotFound') throw error;
 
-		return await super.get(domain, ...args);
+			let normalized;
+			try{
+				normalized = tldExtract(domain).domain;
+			}catch{
+				throw error;
+			}
+			if(normalized === domain) throw error;
+
+			return await super.get(normalized, ...args);
+		}
 	}
 
 	async getRecords(...args){
@@ -121,9 +144,32 @@ class DnsProvider extends Table{
 			let domains = await provider.listDomains();
 
 			let instance = await super.create.call(__intraModel, data, ...args);
-			await instance.updateDomains(domains);
+			try{
+				await instance.updateDomains(domains);
+			}catch(updateError){
+				// Don't leave a half-created provider behind (e.g. a Domain that
+				// collided with a stale/orphaned record from a previous failed
+				// attempt — see updateDomains' own comment on zoneId omission for
+				// another case this can throw). Re-fetch before removing: `instance`
+				// had its `domains` relation resolved by super.create()'s own
+				// internal get() BEFORE updateDomains() created any Domain rows, so
+				// it's permanently stale (always empty) — removing `instance`
+				// directly would delete the provider but silently leave behind
+				// whatever domains updateDomains() managed to create before failing,
+				// which is exactly the kind of orphan this is meant to prevent.
+				try{
+					await (await this.get(instance.id)).remove();
+				}catch(removeError){
+					console.error('DnsProvider create: failed to roll back', instance.id, 'after updateDomains error:', removeError.message);
+				}
+				throw updateError;
+			}
 
-			return instance;
+			// Same staleness issue as above: re-fetch so the returned instance
+			// (and the API response built from it) reflects the domains
+			// updateDomains() actually just created, not the empty snapshot from
+			// before it ran.
+			return await this.get(instance.id);
 		}catch(error){
 			if(error.name === 'UnauthorizedDnsApi'){
 				let keys = [];


### PR DESCRIPTION
## Bug

Reported: adding a DuckDNS provider with `subdomains: "theta42.duckdns.org"`
returned `409 EntryNameUsed: Domain:theta42.duckdns.org already exists` on
a **fresh install with no such domain ever successfully added** — and, on a
separate earlier attempt, a *different* confusing error:
`404 EntryNotFound: Domain:duckdns.org does not exists` (wrong domain name
entirely).

## Root cause 1 — Domain.get() breaks Domain.create()'s own read-back

`Domain.get()` normalized every lookup via `tldExtract` before querying
Redis. `model-redis`'s `Table.create()` stores a new record under the
**literal** key it's given, then calls `this.get()` internally to return the
created instance. For any domain `tldExtract` doesn't recognize as a
shared/public suffix — a DuckDNS name like `myhost.duckdns.org` normalizes to
just `duckdns.org` (tldExtract has no idea `duckdns.org` is shared across many
independent registrants) — that final read-back always missed, and
`create()` threw `EntryNotFound` **despite the record having just been
written successfully**.

Net effect: **no `*.duckdns.org` domain could ever be created**, full stop —
independent of the earlier `subdomains` field-collision (#127) and
double-suffix (#128) fixes, which were both real and necessary but not
sufficient.

Fixed by trying the exact string first, only falling back to the
tldExtract-normalized parent if no exact record exists. This preserves the
original intent (look up an arbitrary hostname like `www.example.com`, find
the `Domain` that governs it, `example.com`) while fixing `create()`'s
read-back of what it just wrote.

## Root cause 2 — a failed create() leaves an orphaned provider behind

`DnsProvider.create()` saves the provider row first, then calls
`updateDomains()` separately. If `updateDomains()` throws — e.g. hitting a
stale orphaned `Domain` left over from an earlier failed attempt (exactly
what root cause 1 was silently producing) — the already-saved provider row
was never cleaned up. The API returned an error, but a broken, domain-less
provider was left behind; repeated retries accumulate more of them.

Fixed by wrapping `updateDomains()` in its own try/catch and removing the
provider on failure.

That fix has its own subtlety: `instance` (from `super.create()`) has its
`domains` relation resolved by `super.create()`'s own internal `get()` call,
which runs **before** `updateDomains()` creates any `Domain` rows — so
`instance.domains` is permanently stale (always empty), on both the success
and failure paths. Removing `instance` directly would delete the provider
but silently leave behind whatever domains `updateDomains()` did manage to
create. Fixed by re-fetching (`this.get(instance.id)`) before both the
success return and the failure-path `remove()`.

## Test plan

This project's test philosophy explicitly excludes Redis-ORM-dependent tests
from the automated suite (`test/README.md`: "NO: Don't test the Redis ORM",
"Mock external services (Redis, DNS APIs)"), so this was manually verified
against a live local Redis instead:
- [x] A pre-existing orphaned `Domain` (simulating root cause 1's fallout)
      now produces an accurate `"already exists"` error naming the *correct*
      domain, instead of a confusing `EntryNotFound` for the wrong
      (normalized) one — and the failed `create()` leaves zero orphaned
      providers behind
- [x] A genuinely new `*.duckdns.org` domain now creates successfully,
      correctly links to its provider (`Domain.get()` finds it by exact
      key), and is fully cascade-deleted when the provider is removed
- [x] `npm test` — 192/192 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)