### PR TITLE
Add a footer, move GitHub link out of the nav

### DIFF
--- a/nodejs/public/img/theta42.svg
+++ b/nodejs/public/img/theta42.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="100%" height="100%">
+  <defs>
+    <linearGradient id="gold-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#C59341" />
+      <stop offset="20%" stop-color="#E4B869" />
+      <stop offset="40%" stop-color="#FBF0B9" />
+      <stop offset="60%" stop-color="#DFB260" />
+      <stop offset="80%" stop-color="#BC8837" />
+      <stop offset="100%" stop-color="#A36F28" />
+    </linearGradient>
+
+    <linearGradient id="text-grad" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#FFFFFF" />
+      <stop offset="40%" stop-color="#F5E3B5" />
+      <stop offset="70%" stop-color="#D4A343" />
+      <stop offset="100%" stop-color="#8A5A16" />
+    </linearGradient>
+
+    <filter id="drop-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="8" stdDeviation="6" flood-color="#000000" flood-opacity="0.4"/>
+    </filter>
+  </defs>
+
+  <g filter="url(#drop-shadow)">
+    <g fill="url(#gold-grad)">
+      <path d="M 200,40 
+               C 290,40 350,110 350,200 
+               C 350,290 290,360 200,360 
+               C 110,360 50,290 50,200 
+               C 50,110 110,40 200,40 Z 
+               M 200,75 
+               C 130,75 88,130 88,200 
+               C 88,270 130,325 200,325 
+               C 270,325 312,270 312,200 
+               C 312,130 270,75 200,75 Z" 
+            fill-rule="evenodd" />
+      
+      <path d="M 88,190 L 140,190 C 140,190 142,210 140,210 L 88,210 Z" />
+      
+      <path d="M 260,190 L 312,190 C 312,190 310,210 260,210 Z" />
+    </g>
+
+    <text x="200" y="222" 
+          font-family="system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" 
+          font-size="78" 
+          font-weight="900" 
+          fill="url(#text-grad)" 
+          text-anchor="middle"
+          letter-spacing="-2">42</text>
+  </g>
+</svg>

--- a/nodejs/routes/render.js
+++ b/nodejs/routes/render.js
@@ -4,10 +4,12 @@ const path = require('path');
 const express = require('express');
 const router = require('express').Router();
 const conf = require('@simpleworkjs/conf');
+const buildInfo = require('../utils/build_info');
 
 const values ={
   title: conf.environment !== 'production' ? `dev` : '',
   titleIcon: conf.environment !== 'production' ? `<i class="fa-brands fa-dev"></i>` : '',
+  ...buildInfo,
 }
 
 // List of front end node modules to be served

--- a/nodejs/utils/build_info.js
+++ b/nodejs/utils/build_info.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { execSync } = require('child_process');
+const { version: buildVersion } = require('../package.json');
+
+let buildHash = 'unknown';
+try {
+	buildHash = execSync('git rev-parse --short HEAD', { cwd: __dirname }).toString().trim();
+} catch (_) {}
+
+module.exports = {
+	buildVersion,
+	buildHash,
+	buildYear: new Date().getFullYear(),
+};

--- a/nodejs/views/bottom.ejs
+++ b/nodejs/views/bottom.ejs
@@ -1,3 +1,21 @@
 		</div>
+
+		<footer class="py-2 bg-dark text-light mt-4">
+			<div class="container-fluid d-flex flex-wrap justify-content-between align-items-center small gap-2">
+				<span class="d-flex align-items-center gap-2">
+					<a href="https://theta42.com" target="_blank">
+						<img width="64" src="/static/img/theta42.svg"/>
+					</a>
+					&copy; <%- buildYear %> theta42 &middot;
+					<a href="https://github.com/theta42/proxy/blob/master/LICENSE" target="_blank" class="text-light">MIT License</a>
+				</span>
+				<span class="d-flex align-items-center gap-3">
+					<a href="https://github.com/theta42/proxy" target="_blank" class="text-light text-decoration-none">
+						<i class="fa-brands fa-github"></i> GitHub
+					</a>
+				</span>
+				<span>v<%- buildVersion %> (<%- buildHash %>)</span>
+			</div>
+		</footer>
     </body>
 </html>

--- a/nodejs/views/top.ejs
+++ b/nodejs/views/top.ejs
@@ -76,11 +76,6 @@
 							API Tokens
 						</a>
 					</li>
-					<li class="nav-item">
-						<a class="nav-link" href="https://github.com/theta42/proxy" target="_blank">
-							<i class="fa-brands fa-github"></i>
-						</a>
-					</li>
 				</ul>
 				<div class="form-inline mt-2 mt-md-0">
 					<a id="cl-username" class="navbar-text text-light me-3" href="/profile" style="display: none;">


### PR DESCRIPTION
## Summary

proxy had no page footer at all — no copyright, no license link, no
build/version info — unlike sso-manager-node, which already had one (now
cleaned up in a matching change: theta42/sso-manager-node#41). Bring the
two in line so both apps feel like one unified product:

- Added a footer to `bottom.ejs`: theta42 logo/link, "© \<year\> theta42"
  with an MIT License link, a GitHub link, and build version/hash.
- Moved the GitHub icon link out of the top nav (where it competed with
  actual navigation items) and into the new footer.
- Added `nodejs/utils/build_info.js` (`buildVersion`/`buildHash`/`buildYear`,
  read once from `package.json` + `git`) and wired it into `routes/render.js`
  so every page has the values the footer needs. Mirrors the same helper
  added to sso-manager-node in its matching cleanup.
- Copied the `theta42.svg` logo into `nodejs/public/img/` (previously only
  present in sso-manager-node) so both apps' footers render identically.

## Test plan
- [x] Rendered `top` + `bottom` with the real `ejs` package: no template
      errors, GitHub link present exactly once (footer, not nav), logo and
      MIT License link present
- [x] `npm test` — 192/192 pass (unaffected — view-only + a new leaf utility
      module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)