### PR TITLE
Wrap unresponsive tables in table-responsive

### DIFF
--- a/nodejs/views/permissions.ejs
+++ b/nodejs/views/permissions.ejs
@@ -143,6 +143,7 @@
 			</div>
 
 			<div class="card-header actionMessage" style="display:none"></div>
+			<div class="table-responsive">
 			<table class="card-body table table-striped" style="margin-bottom:0">
 				<thead>
 					<th>Type</th>
@@ -168,6 +169,7 @@
 					</tr>
 				</tbody>
 			</table>
+			</div>
 		</div>
 	</div>
 </div>

--- a/nodejs/views/profile.ejs
+++ b/nodejs/views/profile.ejs
@@ -91,10 +91,12 @@
 				</div>
 
 				<div class="mb-1 profile-label">Domain permissions</div>
+				<div class="table-responsive">
 				<table class="table table-striped">
 					<thead><th>Domain</th><th>Role</th></thead>
 					<tbody id="profile-domains"></tbody>
 				</table>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/nodejs/views/users.ejs
+++ b/nodejs/views/users.ejs
@@ -112,6 +112,7 @@
 			</div>
 
 			<div class="card-header actionMessage" style="display:none"></div>
+			<div class="table-responsive">
 			<table class="card-body table table-striped" style="margin-bottom:0">
 				<thead>
 					<th>Name</th>
@@ -121,7 +122,7 @@
 				<tbody>
 					<tr jq-repeat="users" jq-repeat-index="username" style="display:none" >
 						<td class="align-middle">
-							{{ username }}	
+							{{ username }}
 						</td>
 						<td>
 
@@ -140,6 +141,7 @@
 					</tr>
 				</tbody>
 			</table>
+			</div>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
## Summary

Auditing mobile/responsive views turned up three data tables missing the
`.table-responsive` wrapper that `hosts.ejs` already has:

- `permissions.ejs` — 6 columns (Type, Subject, Scope, Domain, Role, Delete)
- `users.ejs` — 3 columns, one of which contains an inline password-change
  form (input + button)
- `profile.ejs` — the domain-permissions table

Without the wrapper, these overflow the page horizontally on narrow
viewports instead of scrolling within the table — either clipping content
or forcing the whole page to scroll sideways.

## Test plan
- [x] `ejs.compile()` on all three templates — no errors
- [x] `npm test` — 192/192 pass
- [x] Started the app locally and fetched `/permissions`, `/users`,
      `/profile` — confirmed `table-responsive` present in the served HTML
      for all three

🤖 Generated with [Claude Code](https://claude.com/claude-code)