### PR TITLE
Fix TLS handshake failure for any host without a cached target

### DIFF
--- a/ops/nginx_conf/nginx.conf
+++ b/ops/nginx_conf/nginx.conf
@@ -51,9 +51,15 @@ http {
 		auto_ssl:set("request_domain", function(ssl, ssl_options)
 			local domain, err = ssl.server_name()
 
+			-- targetInfo.get() returns (nil, httpStatus) for an unknown/unregistered
+			-- domain rather than erroring -- that's expected here (e.g. a probe with
+			-- no matching Host record, or no SNI at all). ngx.ctx.toAllow is only
+			-- set on a successful lookup, so allow_domain() correctly denies
+			-- issuance and auto-ssl falls back to the static ssl_certificate in
+			-- autossl.conf.
 			local res = targetInfo.get(ngx, domain, ngx.ctx.targetInfo)
 
-			if res['wildcard_parent'] then
+			if res and res['wildcard_parent'] then
 				return res['wildcard_parent'], err
 			end
 

--- a/ops/nginx_conf/proxy.conf
+++ b/ops/nginx_conf/proxy.conf
@@ -39,7 +39,10 @@ server {
 		local host = ngx.var.host
 		local uri = ngx.var.uri
 		local scheme = ngx.var.scheme
-		local res = targetInfo.get(ngx, host, ngx.ctx.targetInfo)
+		local res, errCode = targetInfo.get(ngx, host, ngx.ctx.targetInfo)
+		if not res then
+			return ngx.exit(errCode or 500)
+		end
 
 		if scheme == "http" then
 			if res["forcessl"] == "true" then

--- a/ops/nginx_conf/targetinfo.lua
+++ b/ops/nginx_conf/targetinfo.lua
@@ -11,7 +11,16 @@ end
 
 print("In targetInfo module")
 
--- Main function of the module
+-- Main function of the module. Returns (res) on success, or (nil, httpStatus)
+-- on failure -- it must NOT call ngx.exit() itself: this is called both from
+-- proxy.conf's access_by_lua_block (a normal request phase, where ngx.exit()
+-- is fine) AND from nginx.conf's request_domain callback, which runs during
+-- the TLS handshake (ssl_certificate_by_lua*). ngx.exit() is not a supported
+-- API in that phase -- calling it there aborts the handshake with a bare
+-- "internal error" TLS alert and no log output, breaking TLS entirely
+-- (including the self-signed fallback cert, since auto-ssl never gets to
+-- fall back gracefully). Callers that can legitimately abort the request
+-- (i.e. proxy.conf) must call ngx.exit() themselves using the returned status.
 function M.get(ngx, domain, targetInfo)
     -- Reuse a previously-resolved target ONLY when it was resolved for this
     -- exact host. HTTP/2 connection coalescing lets a browser serve several
@@ -26,10 +35,9 @@ function M.get(ngx, domain, targetInfo)
 
     local json = require "cjson"
     local redis = require "resty.redis"
-    
+
     if not domain then
-        ngx.exit(499)
-        return false
+        return nil, 499
     end
 
     local red = redis:new()
@@ -38,7 +46,7 @@ function M.get(ngx, domain, targetInfo)
     local ok, err = red:connect("127.0.0.1", 6379)
     if not ok then
         ngx.log(ngx.ERR, "failed to connect to redis: ", err)
-        return ngx.exit(598)
+        return nil, 598
     end
 
     local res, err = red:hgetall("proxy_Host_"..domain)
@@ -53,7 +61,7 @@ function M.get(ngx, domain, targetInfo)
     end
 
     if not res["ip"] then
-        if connect("/var/run/proxy_lookup.socket") then 
+        if connect("/var/run/proxy_lookup.socket") then
             local socket = require("socket.unix")()
             assert(socket:settimeout(.1))
             assert(socket:connect("/var/run/proxy_lookup.socket"))
@@ -70,8 +78,7 @@ function M.get(ngx, domain, targetInfo)
     end
 
     if not res["ip"] then
-        ngx.exit(406)
-        return false
+        return nil, 406
     end
 
     ngx.ctx.targetInfo = res


### PR DESCRIPTION
## Bug

Reported: fallback SSL doesn't work in the Docker build. Reproduced — it's
actually broader than the fallback case specifically. TLS was broken for
nearly every connection, including one with **no SNI at all**:

```
$ curl -vk https://127.0.0.1/
* TLSv1.3 (IN), TLS alert, internal error (592)
* OpenSSL/3.0.13: error:0A000438:SSL routines::tlsv1 alert internal error
```

No log output anywhere (nginx error log, container stdout) — the connection
just died.

## Root cause

`targetinfo.lua`'s `M.get()` is shared by two call sites in two incompatible
nginx phases:

- `proxy.conf`'s `access_by_lua_block` — a normal HTTP request phase, where
  `ngx.exit()` is valid.
- `nginx.conf`'s `request_domain` callback — runs **during the TLS
  handshake itself** (`ssl_certificate_by_lua*`), where `ngx.exit()` is
  **not** a supported API.

`M.get()` called `ngx.exit()` on every lookup failure (no domain/SNI, a
Redis error, or an unregistered host). When invoked from the SSL phase via
`request_domain`, that aborted the handshake with a bare "internal error"
alert — silently, with no log output at all. This happens for *any*
connection that doesn't already have a resolvable target, which is exactly
the fallback-cert scenario (and worse: also a bare no-SNI connection).

## Fix

- `M.get()` no longer calls `ngx.exit()` itself — it returns
  `(nil, httpStatus)` on failure instead.
- `proxy.conf` now checks the return value and calls `ngx.exit()` itself
  (the phase where that's actually supported).
- `nginx.conf`'s `request_domain` guards the now-possibly-`nil` result
  before indexing it, and leaves `ngx.ctx.toAllow` unset on failure so
  `allow_domain()` correctly denies issuance and auto-ssl falls through to
  the static fallback cert in `autossl.conf`.

## Test plan

Verified end to end against a running Docker build — deployed the changed
Lua/conf files into a live container via `docker cp` + `openresty -s reload`
for fast iteration, rather than a full rebuild each time:

- [x] No SNI at all: TLS now completes; HTTP layer correctly returns 406
      (previously: broken handshake, no response at all)
- [x] Unregistered SNI: same — TLS completes, 406, and
      `openssl s_client ... | openssl x509 -noout -subject -issuer` confirms
      the cert served is genuinely the fallback
      (`CN=sni-support-required-for-valid-ssl`)
- [x] A real registered Host (`Host.create` via redis-cli, `forcessl: true`):
      TLS completes and proxies through to the backend correctly (`/health`
      → `200 {"status":"ok"}`) — confirms the success path is unaffected
- [x] `npm test` — 192/192 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)