### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proxy-api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proxy-api",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "author": [
     {


### PR DESCRIPTION
## Summary
- First versioned release since 1.0.0 — includes the standalone backup script and admin update-check banner.

## Test plan
- N/A (version bump only)