### PR TITLE
DuckDNS: validate token via a TXT write, not the A/AAAA record

### DIFF
--- a/nodejs/models/dns_provider/duckdns.js
+++ b/nodejs/models/dns_provider/duckdns.js
@@ -67,14 +67,15 @@ class DuckDns extends DnsApi{
 	}
 
 	// No API to enumerate owned subdomains, so the operator supplies them.
-	// This call both validates the token and, as a side effect, syncs each
-	// domain's A/AAAA record to this host's current public IP if the token
-	// is valid (DuckDNS auto-detects the caller's IP when `ip` is omitted)
-	// — the same thing an operator would need to do anyway when pointing a
-	// fresh DuckDNS domain at this proxy.
+	// This call validates the token by writing a fixed marker to the TXT
+	// record only -- never `ip`/`ipv6` -- so adding/validating a provider
+	// never changes where the domain's A/AAAA records actually point. (An
+	// earlier version omitted `ip` here, which made DuckDNS auto-detect and
+	// apply this host's public IP as a side effect of validation; that's
+	// exactly what this call must not do.)
 	async listDomains(){
 		let labels = this.subdomains.split(',').map(d => this.__normalizeLabel(d.trim())).filter(Boolean);
-		await this.update(labels.join(','), {});
+		await this.update(labels.join(','), {txt: 'theta42-proxy-validated'});
 
 		return labels.map(label => ({domain: `${label}.duckdns.org`}));
 	}


### PR DESCRIPTION
## Summary
- Adding a DuckDNS provider used to instantly push this host's public IP to the domain's A/AAAA record, as a side effect of validating the submitted token (DuckDNS has no read-only validate endpoint, only a single write endpoint).
- `listDomains()` now validates by writing a fixed marker to the TXT record only, leaving A/AAAA untouched. A bad token still throws `UnauthorizedDnsApi` exactly as before.

## Test plan
- [x] `node --test test/integration/dns_provider.test.js` — all 30 tests pass
- [x] Intercepted the real outgoing HTTP request at the wire level: confirmed the querystring now contains `txt` and no `ip`/`ipv6` keys
- [x] Confirmed a `KO` (bad token) response still throws `UnauthorizedDnsApi`, preserving `DnsProvider.create()`'s existing "Invalid Key" UX