### PR TITLE
Add CHANGELOG.md, serve it in-app at /docs/changelog

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,7 @@ ops/proxy.service
 # at /docs (routes/docs.js) so they're readable without internet access.
 *.md
 !README.md
+!CHANGELOG.md
 !DEPLOYMENT.md
 !nodejs/api.md
 !docs/**/*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project are documented here. Format loosely
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
+correspond to git tags (`vX.Y.Z`) and `nodejs/package.json`'s `version`.
+
+## [Unreleased]
+
+## [1.1.2] - 2026-07-16
+
+### Fixed
+- **Air-gap**: `DynamicRecord.refreshAll()` called the public-IP resolvers (`api.ipify.org`, `icanhazip.com`, `ifconfig.me`) every 4h on a timer regardless of whether any dynamic DNS records were configured — the one background network call in the repo not actually gated by feature use. Now skips the lookup entirely when there's nothing to refresh.
+- Removed the stray, unauthenticated `GET /test` page (a leftover jq-repeat demo) that loaded jQuery + Mustache from external CDNs.
+- Removed a dead IE<9-only `html5shim` script tag pointing at a domain that no longer resolves.
+
+### Added
+- **In-app documentation**: `GET /docs` and `GET /docs/:slug` render this project's own README, DEPLOYMENT, `api.md`, and `docs/*.md` server-side — readable from the running app with no dependency on GitHub Pages, which requires internet access to view. Public, no auth, rate-limited.
+
+## [1.1.1] - 2026-07-16
+
+### Fixed
+- **DuckDNS provider**: adding a DuckDNS provider no longer pushes this host's public IP to the domain's live A/AAAA record as a side effect of token validation. Validation now writes a fixed marker to the TXT record instead, leaving routing untouched. ([#142](https://github.com/theta42/proxy/pull/142))
+
+## [1.1.0] - 2026-07-16
+
+First tagged release. Establishes the `vX.Y.Z` tag convention that the in-app update-check banner polls against going forward.
+
+### Added
+- Standalone backup script (`ops/backup.sh`) for deployments not using theta-env's orchestrator — snapshots Redis and `./config`, with retention.
+- Admin-only in-app banner that checks GitHub releases every 24h and surfaces available updates.
+
+[Unreleased]: https://github.com/theta42/proxy/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/theta42/proxy/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/theta42/proxy/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/theta42/proxy/releases/tag/v1.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,7 @@ COPY nodejs/api.md ./api.md
 # flattened /app (mirrors sso-manager-node's tos.md -> /tos.md convention);
 # docs/ mirrors the repo's own top-level docs/ folder.
 COPY README.md /README.md
+COPY CHANGELOG.md /CHANGELOG.md
 COPY DEPLOYMENT.md /DEPLOYMENT.md
 COPY docs /docs
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ proxy serves them over TLS with auto-renewing certs and no downtime on changes.
 > the proxy and the SSO find each other without manual config.
 
 **Documentation:** [https://theta42.github.io/proxy/](https://theta42.github.io/proxy/)
+([CHANGELOG.md](CHANGELOG.md) for what changed in each release) — also
+readable from the running app itself at `/docs`, no internet access required.
 
 ## Screenshots
 

--- a/nodejs/routes/docs.js
+++ b/nodejs/routes/docs.js
@@ -32,6 +32,7 @@ const values = {
 // there's no way to make this read outside the doc set below.
 const DOCS = {
 	overview:     {title: 'Overview',      file: path.join(__dirname, '../../README.md')},
+	changelog:    {title: 'Changelog',     file: path.join(__dirname, '../../CHANGELOG.md')},
 	deployment:   {title: 'Deployment',    file: path.join(__dirname, '../../DEPLOYMENT.md')},
 	api:          {title: 'API Reference', file: path.join(__dirname, '../api.md')},
 	installation: {title: 'Installation',  file: path.join(__dirname, '../../docs/installation.md')},


### PR DESCRIPTION
Closes theta42/theta-env#43.

## Summary
- GitHub Releases already carried real changelog notes per tag, but those require internet access to view -- exactly what the `/docs` route exists to avoid. `CHANGELOG.md` is a committed, Keep-a-Changelog-style file (backfilled from the v1.1.0/v1.1.1/v1.1.2 release notes), linked from README and served at `/docs/changelog` alongside the rest of the project's docs.
- `.dockerignore`/`Dockerfile` updated so `CHANGELOG.md` ships in the built image.

## Test plan
- [x] Verified locally: `/docs/changelog` renders correctly, `/docs` index includes it
- [x] Built the real Docker image and ran it: `/CHANGELOG.md` present at the expected path, `/docs/changelog` returns 200 from inside the running container