### PR TITLE
White-label: title/logo now driven by conf

### DIFF
--- a/nodejs/conf/base.js
+++ b/nodejs/conf/base.js
@@ -2,6 +2,8 @@
 // Using https://github.com/simpleworkjs/conf to handle configuration
 
 module.exports = {
+	name: "Dynamic Proxy", // displayed in the UI
+	logo: "/static/img/theta42.svg", // shown in the nav; point at your own file under public/ (or an absolute URL) to white-label
 	userModel: 'redis', // pam, redis, ldap
 	ldap: {
 		url: 'ldap://192.168.1.55:389',

--- a/nodejs/routes/docs.js
+++ b/nodejs/routes/docs.js
@@ -22,6 +22,8 @@ const docsLimiter = rateLimit({
 const values = {
 	title: conf.environment !== 'production' ? `dev` : '',
 	titleIcon: conf.environment !== 'production' ? `<i class="fa-brands fa-dev"></i>` : '',
+	name: conf.name,
+	logo: conf.logo,
 	...buildInfo,
 };
 

--- a/nodejs/routes/render.js
+++ b/nodejs/routes/render.js
@@ -9,6 +9,8 @@ const buildInfo = require('../utils/build_info');
 const values ={
   title: conf.environment !== 'production' ? `dev` : '',
   titleIcon: conf.environment !== 'production' ? `<i class="fa-brands fa-dev"></i>` : '',
+  name: conf.name,
+  logo: conf.logo,
   ...buildInfo,
 }
 

--- a/nodejs/views/top.ejs
+++ b/nodejs/views/top.ejs
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-		<title>Proxy - Theta 42 <%- title %></title>
+		<title><%- name %> <%- title %></title>
 		<!-- Favicon -->
 		<link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
 		<!-- CSS are placed here -->
@@ -28,7 +28,7 @@
 	<body>
 
 		<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
-			<a class="navbar-brand" href="#">Dynamic Proxy <%- titleIcon %></a>
+			<a class="navbar-brand" href="#"><img src="<%- logo %>" height="28" class="me-2" alt=""><%- name %> <%- titleIcon %></a>
 			<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
 				<span class="navbar-toggler-icon"></span>
 			</button>

--- a/secrets.js.example
+++ b/secrets.js.example
@@ -18,6 +18,9 @@
 // theta-env orchestrator (setup.sh) and ignored by the app.
 
 module.exports = {
+    name: 'Dynamic Proxy',                // shown in the UI
+    logo: '/static/img/theta42.svg',      // nav image; point at your own file under public/ to white-label
+
     // OpenID Connect — point at your SSO Manager. Issuer + authorization/
     // endSession are browser-facing URLs; token/userinfo can be the internal
     // URL if the SSO is on the same docker network (avoids a TLS hairpin).


### PR DESCRIPTION
Closes #45.

## Summary
- `<title>`, the navbar brand text, and the nav logo image were all hardcoded "Proxy - Theta 42"/"Dynamic Proxy". New `conf.name`/`conf.logo` keys (defaults matching the current text/asset) drive them now.
- Same `values` object plumbing pattern already used elsewhere (`routes/render.js` and the separate `routes/docs.js` copy), matching the approach used in sso-manager-node's companion PR.
- Footer (copyright, `theta42.com` link, GitHub/license links) and the existing `favicon.svg` are left untouched -- open-source attribution and a distinct, already-working icon asset (verified it's genuinely different SVG content from the logo, not the same file), not deployment branding.
- `secrets.js.example` documents the new `logo` key alongside the new `name` one.

## Test plan
- [x] Verified locally with default config: title/navbar show "Dynamic Proxy" + the theta42 logo on both `/login` and `/docs`
- [x] Verified with `app_name`/`app_logo` env overrides: title, navbar text, and navbar logo all update correctly on both routes
- [x] Confirmed footer and favicon are unaffected by either config
- [x] `node --test` -- all 192 tests pass