### PR TITLE
Update jq-repeat to 2.1.0; fix removed __setPut/__setTake API

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -21,7 +21,7 @@
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.2",
         "extend": "^3.0.2",
-        "jq-repeat": "^2.0.1",
+        "jq-repeat": "^2.1.0",
         "jquery": "^4.0.0",
         "ldapts": "^8.1.8",
         "linux-sys-user": "^1.2.0",
@@ -1375,9 +1375,9 @@
       "license": "MIT"
     },
     "node_modules/jq-repeat": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jq-repeat/-/jq-repeat-2.0.1.tgz",
-      "integrity": "sha512-ATI25tKQG3uHW8f8XPqBe85JsH4PNGHA/YLy1KgMVeYDoUSf9cqGNBum+4A+Pg1WKh9PA6bYyWfYNsgktwIbSg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jq-repeat/-/jq-repeat-2.1.0.tgz",
+      "integrity": "sha512-e1OmSWeBEHEtyOhNVysx0bnT5wd6HlZ37JZgPcGPmACJ0K9bXDPq0xOwrM1slQMSTw7FOSNDX+MD6VwvPeeZyQ==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -32,7 +32,7 @@
     "express": "^5.2.1",
     "express-rate-limit": "^8.5.2",
     "extend": "^3.0.2",
-    "jq-repeat": "^2.0.1",
+    "jq-repeat": "^2.1.0",
     "jquery": "^4.0.0",
     "ldapts": "^8.1.8",
     "linux-sys-user": "^1.2.0",

--- a/nodejs/views/groups.ejs
+++ b/nodejs/views/groups.ejs
@@ -60,10 +60,10 @@
 
 		loadUserSuggestions();
 
-		$.scope.LocalGroup.__setTake(function($el){
+		$.scope.LocalGroup.__take = function($el){
 			$el.addClass('bg-danger');
 			$el.fadeOut(600, function(){ $el.remove(); });
-		});
+		};
 
 		app.subscribe(/^model:LocalGroup:create/, function(data){
 			$.scope.LocalGroup.remove(data.name);

--- a/nodejs/views/permissions.ejs
+++ b/nodejs/views/permissions.ejs
@@ -57,10 +57,10 @@
 
 		loadSubjectSuggestions();
 
-		$.scope.Permission.__setTake(function($el, item, list){
+		$.scope.Permission.__take = function($el, item, list){
 			$el.addClass('bg-danger');
 			$el.fadeOut(600, function(){ $el.remove(); });
-		});
+		};
 
 		// Live updates (model:Permission:*), so adds/removes reflect for everyone.
 		app.subscribe(/^model:Permission:create/, function(data){

--- a/nodejs/views/users.ejs
+++ b/nodejs/views/users.ejs
@@ -26,12 +26,12 @@
 			for(let user of data.results){
 				$.scope.users.push(user);
 			}
-			$.scope.users.__setPut(function($el, item, list){
+			$.scope.users.__put = function($el, item, list){
 				$el.addClass('bg-success');
 				$el.fadeIn(3000, function(){
 					$el.removeClass('bg-success');
 				});
-			})
+			};
 		});
 	}
 
@@ -45,12 +45,12 @@
 	$(document).ready(function(){
 		populateUsers(); //populate the table
 
-		$.scope.users.__setTake(function($el, item, list){
+		$.scope.users.__take = function($el, item, list){
 			$el.addClass('bg-danger');
 			$el.fadeOut(1000, function(){
 				$el.remove()
 			});
-		});
+		};
 
 	});
 </script>


### PR DESCRIPTION
## Summary
- Bumps `jq-repeat` 2.0.1 -> 2.1.0.
- Audited every usage in this repo against the real [2.1.0 changelog](https://github.com/wmantly/jq-repeat/blob/master/CHANGELOG.md) before upgrading -- full findings in the commit message.
- **Real breakage found and fixed**: `users.ejs`/`groups.ejs`/`permissions.ejs` called `$.scope.X.__setPut(fn)`/`__setTake(fn)` as setter methods -- that API doesn't exist in 2.1.0. Hooks are now set via direct property assignment (`$.scope.X.__put = fn`), matching the current README.
- `push()`/`unshift()` return-value change and `update()` throttling change: audited, no risk in this repo (every call site is a bare statement / nothing reads DOM state right after `update()`).

## Test plan
- [x] `node --test` -- all 192 tests pass
- [x] Live-tested (real dev server + Playwright, logged in as an admin): before the fix, `/users`, `/groups`, and `/permissions` all threw `__setTake is not a function` in the console and the insert/remove row animations silently did nothing; after the fix, zero console errors and the hooks fire correctly
- [x] Confirmed `/hosts` and `/dns` (the other two jq-repeat-consuming pages, which don't use the removed hook API) still render their jq-repeat containers correctly with no new errors