### PR TITLE
hosts.ejs: fix Authentication tab radios not enforcing mutual exclusivity

### DIFF
--- a/nodejs/views/hosts.ejs
+++ b/nodejs/views/hosts.ejs
@@ -115,10 +115,13 @@
 	// attach users to).
 	let hostFormCurrentHost = null;
 
-	// The auth_mode radios aren't real form fields (no [name]); this keeps the
-	// two hidden basicauth_enabled/sso_enabled inputs — the ones actually
-	// submitted — in sync so only one can ever be true, and shows/hides the
-	// matching field group.
+	// The auth_mode radios share a name so the browser enforces mutual
+	// exclusivity, but auth_mode itself isn't in Host's _keyMap -- the model
+	// layer strips unrecognized fields on save (see model-redis's
+	// processKeys), so it's never actually persisted. This keeps the two
+	// hidden basicauth_enabled/sso_enabled inputs -- the real, submitted
+	// fields -- in sync with whichever radio is selected, and shows/hides
+	// the matching field group.
 	function hostAuthModeChanged(mode){
 		$('#basicauth_enabled-hidden').val(mode === 'basic' ? 'true' : 'false');
 		$('#sso_enabled-hidden').val(mode === 'sso' ? 'true' : 'false');
@@ -713,15 +716,15 @@
 
 							<div class="form-group">
 								<div class="radio"><label>
-									<input type="radio" id="auth_mode-none" value="none" checked onchange="hostAuthModeChanged('none')">
+									<input type="radio" name="auth_mode" id="auth_mode-none" value="none" checked onchange="hostAuthModeChanged('none')">
 									Off (public)
 								</label></div>
 								<div class="radio"><label>
-									<input type="radio" id="auth_mode-basic" value="basic" onchange="hostAuthModeChanged('basic')">
+									<input type="radio" name="auth_mode" id="auth_mode-basic" value="basic" onchange="hostAuthModeChanged('basic')">
 									Basic authentication
 								</label></div>
 								<div class="radio"><label>
-									<input type="radio" id="auth_mode-sso" value="sso" onchange="hostAuthModeChanged('sso')">
+									<input type="radio" name="auth_mode" id="auth_mode-sso" value="sso" onchange="hostAuthModeChanged('sso')">
 									Single sign-on (SSO)
 								</label></div>
 							</div>


### PR DESCRIPTION
## Summary
- The Authentication tab's three `auth_mode` radios (Off / Basic authentication / SSO) had no shared `[name]` attribute, so each was its own independent radio group per the HTML spec -- clicking one didn't uncheck the others, letting multiple options show as selected simultaneously.
- Added `name="auth_mode"` to restore standard exclusive radio-group behavior.
- The original comment claimed omitting `[name]` was deliberate, to avoid `formAJAX`'s `$form.find('[name]').serializeObject()` picking it up and submitting an unintended `auth_mode` field. Verified that reasoning is stale: `model-redis`'s `processKeys()` rebuilds the object to save strictly from `Host`'s own `_keyMap`, silently dropping any field not defined there (confirmed directly against `object_validate.js`) -- so an `auth_mode` field in the raw POST body was always going to be discarded before it ever reached storage. Updated the comment to explain the real mechanism.

## Test plan
- [x] `node --test` -- all 192 tests pass
- [x] Verified live (real dev server + Playwright): clicking "Basic authentication" then "SSO" now correctly unchecks the previous selection each time (previously both stayed checked); confirmed the hidden `basicauth_enabled`/`sso_enabled` fields still end up correctly mutually-exclusive after the fix
- [x] Confirmed via a standalone script against `model-redis`'s real `processKeys()` that an unrecognized `auth_mode` key is stripped, not stored or rejected