### PR TITLE
Host form/list UX polish: editable hostname, created-by column, mobile tabs, more help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ correspond to git tags (`vX.Y.Z`) and `nodejs/package.json`'s `version`.
 
 ## [Unreleased]
 
-## [1.1.8] - 2026-07-17
+## [1.1.9] - 2026-07-17
+
+### Added
+- The host list now shows who created each host, and when.
+- Plain (non-wildcard) hosts can now be renamed after creation — the hostname field is no longer permanently locked. Wildcard hosts, wildcard children, and auto-created subdomain cache entries stay locked, since other records reference them by name.
+- More inline help text on the host create/edit form (Target SSL, wildcard matching behavior).
+
+### Fixed
+- The host create/edit modal's tabs could overflow awkwardly on narrow (mobile) screens — they now scroll horizontally instead.
+- Fixed a bug in the vendored `model-redis` library's record-rename path: renaming a record's primary key while another `always`-type field (e.g. `updated_on`) is defined earlier in the schema left a stray, incomplete hash behind under the old key, making that name permanently unavailable for reuse. Worked around in `Host.prototype.update()`.
+
+Bumps to v1.1.9.
 
 ### Fixed
 - **Couldn't attach an existing host to a parent wildcard.** The host edit form's "Parent Wildcard" option submitted correctly, but `Host.prototype.update()` had no `challengeType` handling at all (only `Host.create()` did) — selecting it and saving silently did nothing. Added the same wildcard-parent lookup to `update()`.
@@ -60,7 +71,8 @@ First tagged release. Establishes the `vX.Y.Z` tag convention that the in-app up
 - Standalone backup script (`ops/backup.sh`) for deployments not using theta-env's orchestrator — snapshots Redis and `./config`, with retention.
 - Admin-only in-app banner that checks GitHub releases every 24h and surfaces available updates.
 
-[Unreleased]: https://github.com/theta42/proxy/compare/v1.1.8...HEAD
+[Unreleased]: https://github.com/theta42/proxy/compare/v1.1.9...HEAD
+[1.1.9]: https://github.com/theta42/proxy/compare/v1.1.8...v1.1.9
 [1.1.8]: https://github.com/theta42/proxy/compare/v1.1.7...v1.1.8
 [1.1.7]: https://github.com/theta42/proxy/compare/v1.1.6...v1.1.7
 [1.1.6]: https://github.com/theta42/proxy/compare/v1.1.5...v1.1.6

--- a/nodejs/models/cert.js
+++ b/nodejs/models/cert.js
@@ -14,6 +14,14 @@ async function getCert(host){
 	}
 }
 
+async function setCert(host, cert){
+	try{
+		return await client.SET(`${host}:latest`, JSON.stringify(cert));
+	}catch(error){
+		return {}
+	}
+}
+
 async function deleteCert(host){
 	try{
 		console.log('looking for', host);
@@ -23,4 +31,4 @@ async function deleteCert(host){
 	}
 }
 
-module.exports = {getCert, deleteCert};
+module.exports = {getCert, setCert, deleteCert};

--- a/nodejs/models/host.js
+++ b/nodejs/models/host.js
@@ -2,7 +2,7 @@
 
 const Table = require('.');
 const {Domain} = require('.').models;
-const {deleteCert} = require('./cert');
+const {getCert, setCert, deleteCert} = require('./cert');
 const ModelPs = require('../utils/model_pubsub');
 
 const tldExtract = require('tld-extract').parse_host;
@@ -343,9 +343,42 @@ class Host extends Table{
 				}
 			}
 
+			// Real hostname rename. model-redis's own update() (see super.update()
+			// below) already handles the Redis primary-key RENAME + collision
+			// check, and Host.buildLookUpObj() below already rebuilds the lookup
+			// tree afterward -- but the cert cache (models/cert.js, `${host}:latest`)
+			// is a separate record keyed by hostname string that the generic field
+			// system doesn't know about, so it doesn't move on its own. Only
+			// wildcard hosts (createWildcardCert) ever populate this key -- for a
+			// plain HTTP-01 host this is a no-op (nothing to migrate; auto-ssl
+			// transparently issues a fresh cert under the new name on first
+			// access, same as it does for any newly-created host).
+			let oldHost = this.host;
+			let renaming = data && typeof data.host === 'string' && data.host !== oldHost;
+			if(renaming){
+				let cert = await getCert(oldHost);
+				if(cert && Object.keys(cert).length) await setCert(data.host, cert);
+			}
+
 			let out = await super.update(data, ...args)
 			await this.bustCache(this.host);
 			await Host.buildLookUpObj();
+
+			if(renaming){
+				await deleteCert(oldHost);
+
+				// Work around a model-redis bug (as of ^1.5.0): super.update()'s
+				// field-application loop iterates _keyMap's definition order and
+				// only reassigns this[_key] (this.host) to the NEW value once it
+				// reaches the `host` field itself -- but `updated_on` (always:
+				// true, so always included) is defined BEFORE `host` in _keyMap,
+				// so it gets HSET while this.host is still the OLD name. Redis's
+				// HSET on a non-existent key (the old hash, just RENAMEd away)
+				// silently recreates it -- leaving a stray, incomplete hash under
+				// the old hostname that makes Host.exists(oldHost) wrongly return
+				// true forever, blocking that name from ever being reused.
+				await this.constructor.redisClient.DEL(`${conf.redis.prefix || ''}Host_${oldHost}`);
+			}
 
 			return out;
 		} catch(error){

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proxy-api",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proxy-api",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-api",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "private": true,
   "author": [
     {

--- a/nodejs/views/hosts.ejs
+++ b/nodejs/views/hosts.ejs
@@ -39,6 +39,7 @@
 
 	// Parse the JSON object for a host to something the UI wants
 	function hostParseRow(host) {
+		host['created_on_text'] = moment(host['created_on'], "x").fromNow();
 		host['updated_on_text'] = moment(host['updated_on'], "x").fromNow();
 		host['wildcard_expires_text'] = moment(host['wildcard_expires'], "x").fromNow();
 		host['targetssl_text'] = host['targetssl'] ? 'https://' : 'http://';
@@ -191,6 +192,7 @@
 		let $f = $(form);
 		$f.attr('method', 'POST').attr('action', 'host').attr('evalAJAX', 'hostModalClose()');
 		$f.find('[name=host]').prop('disabled', false);
+		$('#host-rename-help').hide();
 		if($f.validateClear) $f.validateClear();
 
 		// A fresh host only qualifies for HTTP-01 until the name says otherwise.
@@ -247,9 +249,15 @@
 		hostAuthModeChanged(authMode);
 		hostRenderBasicAuthUsers(host, h.basicauth_users);
 
-		// The host name is the key; it can't change on edit. Wildcard hosts can
-		// still toggle their matching mode.
-		$f.find('[name=host]').prop('disabled', true);
+		// The host name is the Redis record's key -- renaming it is a real
+		// migration (see Host.prototype.update() in models/host.js), scoped
+		// there to plain hosts only: a wildcard's children reference it by
+		// name (wildcard_parent) and a cache entry's parent likewise, so
+		// renaming either would orphan those pointers. Keep the field locked
+		// for those cases; a plain host can be renamed freely.
+		let hostRenameable = !h.is_wildcard && !h.wildcard_parent && !h.is_cache;
+		$f.find('[name=host]').prop('disabled', !hostRenameable);
+		$('#host-rename-help').toggle(!hostRenameable);
 		if(h.is_wildcard){
 			$('#wildcard_matchAny-container').removeClass('challengeType-container');
 		}
@@ -423,6 +431,7 @@
 						<th>SSL Expire</th>
 						<th>Host Name</th>
 						<th>target</th>
+						<th class="hidden-xs">Created</th>
 						<th class="hidden-xs">Updated</th>
 						<th>Actions</th>
 					</thead>
@@ -453,6 +462,11 @@
 							</td>
 							<td>
 								{{{ targetssl_text }}}{{ ip }}:{{ targetPort }}
+							</td>
+							<td class="hidden-xs momentFromNow" data-date="{{ created_on }}" title="Created by {{ created_by }}">
+								{{ created_on_text }}
+								<br />
+								<small class="text-muted">{{ created_by }}</small>
 							</td>
 							<td class="hidden-xs momentFromNow" data-date="{{ updated_on }}" >
 								{{ updated_on_text }}
@@ -519,7 +533,7 @@
 			<div class="card-header actionMessage m-0" style="display:none"></div>
 
 			<div class="modal-body">
-				<ul class="nav nav-tabs" role="tablist">
+				<ul class="nav nav-tabs flex-nowrap overflow-x-auto" role="tablist">
 					<li class="nav-item"><button class="nav-link active" id="hostTab-general-btn" data-bs-toggle="tab" data-bs-target="#hostTab-general" type="button" role="tab">General</button></li>
 					<li class="nav-item"><button class="nav-link" id="hostTab-tls-btn" data-bs-toggle="tab" data-bs-target="#hostTab-tls" type="button" role="tab">TLS &amp; Wildcard</button></li>
 					<li class="nav-item"><button class="nav-link" id="hostTab-traffic-btn" data-bs-toggle="tab" data-bs-target="#hostTab-traffic" type="button" role="tab">Traffic</button></li>
@@ -541,6 +555,12 @@
 									The public hostname clients request. Use <code>*.example.com</code>
 									for one subdomain level, <code>**.example.com</code> for any depth,
 									or <code>**</code> as a catch-all.
+								</small>
+								<small id="host-rename-help" class="field-help text-muted d-block" style="display:none">
+									Wildcard hosts, their children, and auto-created subdomain cache
+									entries can't be renamed here — the name is referenced elsewhere
+									(the wildcard's own children, or the cache entry's parent). Delete
+									and recreate instead.
 								</small>
 							</div>
 
@@ -582,6 +602,7 @@
 										<input type="radio" name="targetssl" id="targetssl-true" value="true">
 										Proxy to HTTPS
 									</label></div>
+									<small class="field-help text-muted d-block">Whether the proxy talks to the target over HTTP or HTTPS. Independent of Incoming SSL above — clients can use HTTPS to reach the proxy while it still talks plain HTTP to the target, or vice versa.</small>
 								</div>
 							</div>
 						</div>
@@ -620,6 +641,14 @@
 									<input type="radio" name="wildcard_matchAny" id="wildcard_matchAny-true" value="true">
 									Match any subdomain and proxy to this host
 								</label></div>
+								<small class="field-help text-muted d-block">
+									"Recommended" only routes subdomains you've explicitly registered
+									as their own host (optionally as a "Parent Wildcard" child of this
+									one, to reuse this cert). "Match any" auto-creates a temporary
+									route to this host's target for <i>any</i> undefined subdomain the
+									first time it's requested — convenient, but it means every subdomain
+									typo or scan attempt also gets routed here.
+								</small>
 							</div>
 						</div>
 


### PR DESCRIPTION
## Summary

- **Plain hosts can now be renamed** after creation — the hostname field was previously locked unconditionally. Wildcard hosts, wildcard children, and auto-created subdomain cache entries stay locked, since other records reference them by name (`wildcard_parent`, cache `.parent`). Migrates the cert cache key (`${host}:latest`) on rename.
- **Host list now shows who created each host, and when** — the data (`created_by`/`created_on`) already existed on every record, this just surfaces it.
- **Host modal tabs now scroll horizontally on narrow screens** instead of overflowing awkwardly.
- **More inline help text** on the create/edit form (Target SSL, wildcard matching behavior), matching the form's existing `.field-help` convention.

### A real bug found and fixed along the way

While verifying the rename feature, I found a genuine bug in the vendored `model-redis` library (`^1.5.0`, not something introduced here): its rename path (triggered when a record's primary key changes) applies changed fields via a loop ordered by the schema's field-definition order, and only reassigns the in-memory primary key partway through that loop — when it reaches the primary-key field itself. Since `updated_on` (an `always: true` field) is defined *before* `host` in `Host._keyMap`, it gets written while the primary key reference is still the *old* value, which — because Redis's `HSET` on a non-existent key just creates one — silently recreates a stray, incomplete hash under the old hostname right after it was renamed away. This made `Host.exists(oldName)` wrongly return `true` forever, permanently blocking that hostname from being reused. Worked around in `Host.prototype.update()` (can't patch a real npm dependency in `node_modules`).

Bumps to v1.1.9.

## Test plan
- [x] Full unit test suite (167 tests) passes, no regressions
- [x] Verified the actual `Host` model against an isolated, disposable Redis container (not the mocked test logic): create → rename → confirms old hash + cert cache key gone, new ones correct, lookup tree updated, **and the old hostname can be successfully reused afterward** (proving the model-redis bug fix)
- [x] Verified the real `getCert`/`setCert`/`deleteCert` migration path directly (cert.js uses its own unconfigurable Redis client, confirmed via the app's Dockerfile/compose that this always correctly matches production — Redis is always colocated in the same container in every supported deployment shape)
- [x] Directly rendered `hosts.ejs` via the `ejs` package (bypassing the full app/auth stack, which needs live OIDC) — confirms no template syntax errors and all new markup (created-by column, rename help text, mobile tab scroll class, new field-help blocks) is present in the output

**Note on test methodology**: my first verification attempt against `models/host.js` accidentally connected to a real local Redis instance (a config/env-var mismatch, since `model-redis`'s connection options are nested under `redis.redisConf.*`, not `redis.port` directly) and wrote a handful of obviously-fake host records there. I caught this, precisely identified and removed only the fake entries I'd introduced, confirmed all pre-existing real data was untouched, and re-ran every verification against a properly isolated container. No ACME/DNS calls were made at any point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDEx8ghuZR61pqPXc6da9C