### PR TITLE
Add header help icon and in-app docs search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ correspond to git tags (`vX.Y.Z`) and `nodejs/package.json`'s `version`.
 
 ## [Unreleased]
 
-## [1.1.9] - 2026-07-17
+## [1.1.10] - 2026-07-17
+
+### Added
+- A help icon (❓) in the top-right header now deep-links to the doc most relevant to the current page (falls back to the docs index elsewhere).
+- The in-app docs viewer (`/docs`) is now searchable — a simple line-substring search over the same local doc set, no new dependency, still works with no internet access.
+
+Bumps to v1.1.10.
 
 ### Added
 - The host list now shows who created each host, and when.
@@ -71,7 +77,8 @@ First tagged release. Establishes the `vX.Y.Z` tag convention that the in-app up
 - Standalone backup script (`ops/backup.sh`) for deployments not using theta-env's orchestrator — snapshots Redis and `./config`, with retention.
 - Admin-only in-app banner that checks GitHub releases every 24h and surfaces available updates.
 
-[Unreleased]: https://github.com/theta42/proxy/compare/v1.1.9...HEAD
+[Unreleased]: https://github.com/theta42/proxy/compare/v1.1.10...HEAD
+[1.1.10]: https://github.com/theta42/proxy/compare/v1.1.9...v1.1.10
 [1.1.9]: https://github.com/theta42/proxy/compare/v1.1.8...v1.1.9
 [1.1.8]: https://github.com/theta42/proxy/compare/v1.1.7...v1.1.8
 [1.1.7]: https://github.com/theta42/proxy/compare/v1.1.6...v1.1.7

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proxy-api",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proxy-api",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-api",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "private": true,
   "author": [
     {

--- a/nodejs/routes/docs.js
+++ b/nodejs/routes/docs.js
@@ -60,6 +60,30 @@ router.get('/', function(req, res) {
 	res.render('docs_index', {...values, docs: docList});
 });
 
+// Plain, dependency-free line-substring search over the same allowlisted
+// doc set -- no separate index to build/maintain, no new dependency, and it
+// keeps working with no internet access (same reasoning as the rest of this
+// route). Must be registered before the /:slug catch-all below, or "search"
+// would be treated as a (nonexistent) doc slug and 404.
+router.get('/search', function(req, res) {
+	const q = (req.query.q || '').trim();
+	if (!q) return res.json({results: []});
+	const qLower = q.toLowerCase();
+
+	const results = [];
+	for (const [slug, doc] of Object.entries(DOCS)) {
+		try {
+			const content = fs.readFileSync(doc.file, 'utf8');
+			const matchLine = content.split('\n').find(line => line.toLowerCase().includes(qLower));
+			if (matchLine) {
+				results.push({slug, title: doc.title, snippet: matchLine.trim().slice(0, 200)});
+			}
+		} catch (error) { /* unreadable doc file -- skip it */ }
+	}
+
+	res.json({results});
+});
+
 router.get('/:slug', function(req, res, next) {
 	const doc = DOCS[req.params.slug];
 	if (!doc) return next({status: 404, message: 'Doc not found'});

--- a/nodejs/views/docs_index.ejs
+++ b/nodejs/views/docs_index.ejs
@@ -11,7 +11,12 @@
 					A local copy of this project's documentation, readable from the
 					running app -- no internet access required.
 				</p>
-				<ul class="list-group">
+				<div class="input-group mb-3">
+					<span class="input-group-text"><i class="fa-solid fa-magnifying-glass"></i></span>
+					<input type="search" id="docs-search-input" class="form-control" placeholder="Search the docs…" oninput="docsSearch(this.value)">
+				</div>
+				<div id="docs-search-results" style="display:none"></div>
+				<ul id="docs-list" class="list-group">
 					<% docs.forEach(function(doc){ %>
 						<li class="list-group-item">
 							<a href="/docs/<%= doc.slug %>"><%= doc.title %></a>
@@ -22,5 +27,41 @@
 		</div>
 	</div>
 </div>
+<script type="text/javascript">
+	var docsSearchTimer;
+	function docsSearch(q){
+		clearTimeout(docsSearchTimer);
+		docsSearchTimer = setTimeout(function(){ docsSearchRun(q); }, 200);
+	}
+	function docsSearchRun(q){
+		q = (q || '').trim();
+		var $results = $('#docs-search-results');
+		var $list = $('#docs-list');
+		if(!q){
+			$results.hide().empty();
+			$list.show();
+			return;
+		}
+		// Not app.api.get() -- routes/docs.js is mounted at /docs directly,
+		// not under /api, unlike the rest of this app's endpoints.
+		$.getJSON('/docs/search', {q: q}, function(data){
+			$list.hide();
+			$results.empty().show();
+			var hits = (data && data.results) || [];
+			if(!hits.length){
+				$results.append($('<p class="text-muted"></p>').text('No results for "' + q + '".'));
+				return;
+			}
+			var $ul = $('<ul class="list-group"></ul>');
+			hits.forEach(function(hit){
+				var $li = $('<li class="list-group-item"></li>');
+				$('<a></a>').attr('href', '/docs/' + hit.slug).text(hit.title).appendTo($li);
+				$('<div class="text-muted small"></div>').text(hit.snippet).appendTo($li);
+				$ul.append($li);
+			});
+			$results.append($ul);
+		});
+	}
+</script>
 
 <%- include('bottom') %>

--- a/nodejs/views/top.ejs
+++ b/nodejs/views/top.ejs
@@ -62,6 +62,9 @@
 					</li>
 				</ul>
 				<div class="form-inline mt-2 mt-md-0">
+					<a id="cl-help" class="nav-link text-light me-3" href="/docs" title="Help">
+						<i class="fa-solid fa-circle-question"></i>
+					</a>
 					<a id="cl-username" class="navbar-text text-light me-3" href="/profile" style="display: none;">
 						<i class="fa-solid fa-user me-1"></i><span id="cl-username-text"></span>
 					</a>
@@ -102,6 +105,21 @@
 				sessionStorage.setItem('update-banner-dismissed', '1');
 			}
 
+			// Deep-link the header help icon to whichever doc is most relevant to
+			// the current page. No server-side "current section" local exists
+			// (every res.render() call shares one values object, see
+			// routes/render.js), so this follows the same client-side
+			// path-matching convention already used for the top-nav active-link
+			// highlighting just below. Unmapped pages fall back to the docs
+			// index (already /docs, the anchor's default).
+			var HELP_DOCS_BY_PATH = {
+				'/hosts': 'installation',
+				'/dns': 'installation',
+				'/users': 'architecture',
+				'/permissions': 'architecture',
+				'/groups': 'architecture',
+			};
+
 			$(document).ready(function(){
 
 				// Set the correct link to active in the top nav bar
@@ -112,6 +130,9 @@
 						$this.addClass('active')
 					}
 				})
+
+				let helpSlug = HELP_DOCS_BY_PATH[window.location.pathname.toLocaleLowerCase()];
+				if(helpSlug) $('#cl-help').attr('href', '/docs/' + helpSlug);
 
 				// Set the correct login/logout button, and reveal admin-only nav
 				// items for global admins.


### PR DESCRIPTION
## Summary
- A ❓ icon in the top-right header now deep-links to the doc most relevant to the current page (Hosts/DNS → Installation, Users/Permissions/Groups → Architecture, everything else → docs index). Client-side path mapping, matching the existing pattern already used for top-nav active-link highlighting.
- The in-app docs viewer (`/docs`) is now searchable — `GET /docs/search?q=` does a plain line-substring search over the existing allowlisted doc set. No new dependency, still works with no internet access.

Bumps to v1.1.10.

## Test plan
- [x] Full unit test suite (167 tests) passes
- [x] Verified the search logic directly against the real doc files (README/CHANGELOG/DEPLOYMENT/api.md/docs/*.md) — correct matches and snippets, empty result for a nonsense query
- [x] Directly rendered `docs_index.ejs` and `top.ejs` via the `ejs` package — confirms no template syntax errors and both the search box and help icon markup are present in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDEx8ghuZR61pqPXc6da9C