### PR TITLE
Move help links from the global header onto each relevant card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ correspond to git tags (`vX.Y.Z`) and `nodejs/package.json`'s `version`.
 
 ## [Unreleased]
 
-## [1.1.10] - 2026-07-17
+## [1.1.11] - 2026-07-17
+
+### Changed
+- Moved the help (❓) link out of the global header and onto each relevant card individually (Proxy List, Add/Edit host, Add DNS Provider, Dynamic A Records, Add New User, User List, Add Permission, Permissions, Add Group) — each now deep-links straight to the doc that actually covers it, instead of one generic header icon.
+
+Bumps to v1.1.11.
 
 ### Added
 - A help icon (❓) in the top-right header now deep-links to the doc most relevant to the current page (falls back to the docs index elsewhere).
@@ -77,7 +82,8 @@ First tagged release. Establishes the `vX.Y.Z` tag convention that the in-app up
 - Standalone backup script (`ops/backup.sh`) for deployments not using theta-env's orchestrator — snapshots Redis and `./config`, with retention.
 - Admin-only in-app banner that checks GitHub releases every 24h and surfaces available updates.
 
-[Unreleased]: https://github.com/theta42/proxy/compare/v1.1.10...HEAD
+[Unreleased]: https://github.com/theta42/proxy/compare/v1.1.11...HEAD
+[1.1.11]: https://github.com/theta42/proxy/compare/v1.1.10...v1.1.11
 [1.1.10]: https://github.com/theta42/proxy/compare/v1.1.9...v1.1.10
 [1.1.9]: https://github.com/theta42/proxy/compare/v1.1.8...v1.1.9
 [1.1.8]: https://github.com/theta42/proxy/compare/v1.1.7...v1.1.8

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proxy-api",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proxy-api",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-api",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "private": true,
   "author": [
     {

--- a/nodejs/views/dns.ejs
+++ b/nodejs/views/dns.ejs
@@ -125,6 +125,7 @@
 					Add DNS Provider
 				</span>
 				<span class="float-end">
+					<a href="/docs/installation" class="text-reset me-2" title="Help"><i class="fa-solid fa-circle-question"></i></a>
 					<i class="fa-solid fa-circle-minus"></i>
 				</span>
 			</div>
@@ -226,6 +227,7 @@
 			<div class="card-header d-flex align-items-center">
 				<span class="card-icon me-2"><i class="fa-solid fa-tower-broadcast"></i></span>
 				<span class="card-title">Dynamic A Records</span>
+				<a href="/docs/installation" class="text-reset ms-2" title="Help"><i class="fa-solid fa-circle-question"></i></a>
 				<span class="ms-auto text-muted small">
 					This server's public IP:
 					<span class="badge text-bg-primary fs-6"><i class="fa-solid fa-globe me-1"></i><span id="ddns-current-ip">…</span></span>

--- a/nodejs/views/groups.ejs
+++ b/nodejs/views/groups.ejs
@@ -86,6 +86,7 @@
 			<div class="card-header text-center">
 				<span class="card-icon float-start"><i class="fa-solid fa-users-gear"></i></span>
 				<span class="card-title">Add Group</span>
+				<a href="/docs/architecture" class="text-reset float-end" title="Help"><i class="fa-solid fa-circle-question"></i></a>
 			</div>
 			<div class="card-header actionMessage" style="display:none"></div>
 			<div class="card-body">

--- a/nodejs/views/hosts.ejs
+++ b/nodejs/views/hosts.ejs
@@ -394,6 +394,7 @@
 				<span class="card-icon me-2"><i class="fa-solid fa-network-wired"></i></span>
 				<span class="card-title fw-bold">Proxy List</span>
 				<span class="ms-auto">
+					<a href="/docs/installation" class="text-reset me-2" title="Help"><i class="fa-solid fa-circle-question"></i></a>
 					<button type="button" class="btn btn-sm btn-outline-secondary me-2" onclick="hostClearCache(this)" title="Clear cached wildcard subdomain lookups">
 						<i class="fa-solid fa-broom"></i>
 						Clear cache
@@ -527,6 +528,7 @@
 		<div class="modal-content card border-0">
 			<div class="modal-header">
 				<h5 class="modal-title" id="hostModalTitle">Add host</h5>
+				<a href="/docs/installation" class="text-reset me-2" title="Help"><i class="fa-solid fa-circle-question"></i></a>
 				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
 			</div>
 

--- a/nodejs/views/permissions.ejs
+++ b/nodejs/views/permissions.ejs
@@ -85,6 +85,7 @@
 					<i class="fa-solid fa-user-shield"></i>
 				</span>
 				<span class="card-title">Add Permission</span>
+				<a href="/docs/architecture" class="text-reset float-end" title="Help"><i class="fa-solid fa-circle-question"></i></a>
 			</div>
 
 			<div class="card-header actionMessage" style="display:none"></div>
@@ -140,6 +141,7 @@
 					<i class="fa-solid fa-list-check"></i>
 				</span>
 				<span class="card-title">Permissions</span>
+				<a href="/docs/architecture" class="text-reset float-end" title="Help"><i class="fa-solid fa-circle-question"></i></a>
 			</div>
 
 			<div class="card-header actionMessage" style="display:none"></div>

--- a/nodejs/views/top.ejs
+++ b/nodejs/views/top.ejs
@@ -62,9 +62,6 @@
 					</li>
 				</ul>
 				<div class="form-inline mt-2 mt-md-0">
-					<a id="cl-help" class="nav-link text-light me-3" href="/docs" title="Help">
-						<i class="fa-solid fa-circle-question"></i>
-					</a>
 					<a id="cl-username" class="navbar-text text-light me-3" href="/profile" style="display: none;">
 						<i class="fa-solid fa-user me-1"></i><span id="cl-username-text"></span>
 					</a>
@@ -105,21 +102,6 @@
 				sessionStorage.setItem('update-banner-dismissed', '1');
 			}
 
-			// Deep-link the header help icon to whichever doc is most relevant to
-			// the current page. No server-side "current section" local exists
-			// (every res.render() call shares one values object, see
-			// routes/render.js), so this follows the same client-side
-			// path-matching convention already used for the top-nav active-link
-			// highlighting just below. Unmapped pages fall back to the docs
-			// index (already /docs, the anchor's default).
-			var HELP_DOCS_BY_PATH = {
-				'/hosts': 'installation',
-				'/dns': 'installation',
-				'/users': 'architecture',
-				'/permissions': 'architecture',
-				'/groups': 'architecture',
-			};
-
 			$(document).ready(function(){
 
 				// Set the correct link to active in the top nav bar
@@ -130,9 +112,6 @@
 						$this.addClass('active')
 					}
 				})
-
-				let helpSlug = HELP_DOCS_BY_PATH[window.location.pathname.toLocaleLowerCase()];
-				if(helpSlug) $('#cl-help').attr('href', '/docs/' + helpSlug);
 
 				// Set the correct login/logout button, and reveal admin-only nav
 				// items for global admins.

--- a/nodejs/views/users.ejs
+++ b/nodejs/views/users.ejs
@@ -66,6 +66,7 @@
 					Add New User
 				</span>
 				<span class="float-end">
+					<a href="/docs/architecture" class="text-reset me-2" title="Help"><i class="fa-solid fa-circle-question"></i></a>
 					<i class="fa-solid fa-circle-minus"></i>
 				</span>
 			</div>
@@ -107,6 +108,7 @@
 					User List
 				</span>
 				<span class="float-end">
+					<a href="/docs/architecture" class="text-reset me-2" title="Help"><i class="fa-solid fa-circle-question"></i></a>
 					<i class="fa-solid fa-circle-minus"></i>
 				</span>
 			</div>


### PR DESCRIPTION
## Summary

Same feedback/fix as sso-manager-node's equivalent PR: the header-wide help icon (added last release) pointed at a per-page doc guess, but a page can have several cards for different topics. Removed the global header icon + its client-side path-mapping logic, and added a small ❓ directly to each card that has real corresponding documentation, linking straight to it:

- **hosts.ejs**: Proxy List card, Add/Edit host modal → `/docs/installation`
- **dns.ejs**: Add DNS Provider, Dynamic A Records → `/docs/installation`
- **users.ejs**: Add New User, User List → `/docs/architecture`
- **permissions.ejs**: Add Permission, Permissions → `/docs/architecture`
- **groups.ejs**: Add Group → `/docs/architecture`

Repeated per-item cards (individual DNS providers, local groups) were left alone rather than adding a redundant icon to every row.

Bumps to v1.1.11.

## Test plan
- [x] Full unit test suite (167 tests) passes
- [x] All edited templates compile cleanly via `ejs.compile()`
- [x] Directly rendered `hosts.ejs` and `top.ejs` via the `ejs` package — confirms 2 correct help links present on `hosts.ejs` (list card + modal) and the old global `#cl-help` icon is gone from `top.ejs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDEx8ghuZR61pqPXc6da9C