### PR TITLE
Bump @simpleworkjs/conf to 1.2.0, jq-repeat to 2.2.0

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,13 +9,14 @@
 #   3. OpenResty        (80/443/4443) — exec'd in the foreground as PID 2 (under
 #                      dumb-init, PID 1) so it receives SIGTERM from `docker stop`.
 #
-# The app reads its config from conf/base.js deep-merged with conf/secrets.js
-# and `app_*` env vars (requires @simpleworkjs/conf >= 1.1.0, pinned in
+# The app reads its config from conf/base.js deep-merged with a secrets file
+# and `app_*` env vars (requires @simpleworkjs/conf >= 1.2.0, pinned in
 # nodejs/package-lock.json). No secrets.js is baked into the image. The unified
 # theta-env stack mounts ./config/proxy-secrets.js at /config; this entrypoint
-# symlinks it into /app/conf/secrets.js so the app reads oidc/ldap/auth config
-# from the file (no app_* env needed). Without the mount, supply the same config
-# via `app_*` env (compose `environment:` / `env_file:`).
+# points CONF_SECRETS at it so the app reads oidc/ldap/auth config straight
+# from the mounted file (no app_* env needed, no write access to /app/conf
+# required). Without the mount, supply the same config via `app_*` env
+# (compose `environment:` / `env_file:`).
 #
 # OpenResty config: the committed ops/nginx_conf/*.conf carry the bare-metal
 # home-LAN values (set_real_ip_from 192.168.1.0/24; resolver 192.168.1.1). They
@@ -30,14 +31,14 @@ error() { echo "[ERROR] $*" >&2; }
 
 # ── Optional: mount proxy secrets.js ─────────────────────────────────────────
 # When /config/proxy-secrets.js is present (unified theta-env stack, or any
-# deployment that bind-mounts ./config), symlink it into /app/conf/secrets.js so
-# @simpleworkjs/conf reads the oidc/ldap/auth config from the file. No app_* env
-# should then be passed — app_* env beats secrets.js in @simpleworkjs/conf
+# deployment that bind-mounts ./config), point CONF_SECRETS at it so
+# @simpleworkjs/conf reads the oidc/ldap/auth config from the file. No app_*
+# env should then be passed — app_* env beats secrets.js in @simpleworkjs/conf
 # (precedence: base.js < <env>.js < secrets.js < app_* env), so the file is
 # authoritative only if the matching app_* env is absent. When the file is
 # absent the app falls back to app_* env (compose environment / env_file).
 if [[ -f /config/proxy-secrets.js ]]; then
-    ln -sf /config/proxy-secrets.js /app/conf/secrets.js
+    export CONF_SECRETS=/config/proxy-secrets.js
     info "Loaded config from /config/proxy-secrets.js (secrets.js authoritative)"
 fi
 

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -281,9 +281,9 @@
       }
     },
     "node_modules/@simpleworkjs/conf": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@simpleworkjs/conf/-/conf-1.1.0.tgz",
-      "integrity": "sha512-MKRQQ4JAH2tbEm87NdkmfikTT58Tyk/SFbvCC7zKja0bK6j8zYyBXTQUJ0rnvFOVEalDWd/au4AEiptOCEqgvA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simpleworkjs/conf/-/conf-1.2.0.tgz",
+      "integrity": "sha512-X4u1oRb0A0x7wzmyiIH5hPYYIFJYUXhYVe9CPX6G6INouRIeZuHlx0pthHlihiAAIc3+KqZBx18qirFN8RoJwA==",
       "license": "MIT",
       "dependencies": {
         "extend": "^3.0.2"
@@ -1375,9 +1375,9 @@
       "license": "MIT"
     },
     "node_modules/jq-repeat": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/jq-repeat/-/jq-repeat-2.1.0.tgz",
-      "integrity": "sha512-e1OmSWeBEHEtyOhNVysx0bnT5wd6HlZ37JZgPcGPmACJ0K9bXDPq0xOwrM1slQMSTw7FOSNDX+MD6VwvPeeZyQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jq-repeat/-/jq-repeat-2.2.0.tgz",
+      "integrity": "sha512-OdKAQJ8SOTZzoNL/76o5+WJehXnMCoP8aXbDtZCmDh3vuGGdXfN14FkPTqLpZC5xmlv+QVfTXu/UaIRsDjVuhA==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.3.0",
     "@popperjs/core": "^2.11.8",
-    "@simpleworkjs/conf": "^1.1.0",
+    "@simpleworkjs/conf": "^1.2.0",
     "acme-client": "^5.4.0",
     "axios": "^1.13.5",
     "bcrypt": "^6.0.0",
@@ -32,7 +32,7 @@
     "express": "^5.2.1",
     "express-rate-limit": "^8.5.2",
     "extend": "^3.0.2",
-    "jq-repeat": "^2.1.0",
+    "jq-repeat": "^2.2.0",
     "jquery": "^4.0.0",
     "ldapts": "^8.1.8",
     "linux-sys-user": "^1.2.0",


### PR DESCRIPTION
## Summary
- conf 1.2.0 adds `CONF_SECRETS`, an env var that points directly at the secrets file. The Docker entrypoint now sets `CONF_SECRETS=/config/proxy-secrets.js` instead of symlinking the mounted file into `/app/conf/secrets.js` — the app no longer needs write access to its own `conf/` directory to pick up mounted secrets.
- jq-repeat 2.2.0 is a compatible feature release (`sort()`, `replace()`, faster leading-edge `update()` timing). No call-site changes needed.

## Test plan
- [x] `npm test` — 200/200 passing
- [x] Built the Docker image, mounted a test secrets file, confirmed via `/proc/<pid>/environ` that the running app process has `CONF_SECRETS` set and no symlink is created at `/app/conf/secrets.js`
- [x] Confirmed the mounted config value is actually picked up by `@simpleworkjs/conf` inside the running container
- [x] `/health` responds OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)