### PR TITLE
Bump version to 1.1.17; update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ correspond to git tags (`vX.Y.Z`) and `nodejs/package.json`'s `version`.
 
 ## [Unreleased]
 
+## [1.1.17] - 2026-07-20
+
+### Fixed
+- An existing single-label subdomain host (e.g. `sso.nl.wgnode.com`) could not be attached to a wildcard cert added later (e.g. `*.nl.wgnode.com`): `Host.lookUpWildcardParent()` only checked the wildcard-as-child position (the wildcard's own base domain) and missed the far more common wildcard-as-sibling case, so the edit form's "Parent Wildcard" option stayed permanently greyed out. It now checks both positions, and a regression test covers the sibling case.
+
 ## [1.1.16] - 2026-07-18
 
 ### Changed
@@ -18,7 +23,6 @@ correspond to git tags (`vX.Y.Z`) and `nodejs/package.json`'s `version`.
 - The Unix socket JSON-RPC socket is now created with mode `660` instead of world-writable `777`.
 
 ### Fixed
-- An existing single-label subdomain host (e.g. `sso.nl.wgnode.com`) could not be attached to a wildcard cert added later (e.g. `*.nl.wgnode.com`): `Host.lookUpWildcardParent()` only checked the wildcard-as-child position (the wildcard's own base domain) and missed the far more common wildcard-as-sibling case, so the edit form's "Parent Wildcard" option stayed permanently greyed out. It now checks both positions.
 - The global error handler no longer leaks `err.keys`, stack traces, or other internal details in JSON responses; only `name` and `message` are returned to clients.
 - `DEPLOYMENT.md` and `docs/docker.md` now correctly describe the `CONF_SECRETS` env-var mechanism instead of the old symlink behavior.
 
@@ -128,7 +132,9 @@ First tagged release. Establishes the `vX.Y.Z` tag convention that the in-app up
 - Standalone backup script (`ops/backup.sh`) for deployments not using theta-env's orchestrator — snapshots Redis and `./config`, with retention.
 - Admin-only in-app banner that checks GitHub releases every 24h and surfaces available updates.
 
-[Unreleased]: https://github.com/theta42/proxy/compare/v1.1.16...HEAD
+[Unreleased]: https://github.com/theta42/proxy/compare/v1.1.17...HEAD
+[1.1.17]: https://github.com/theta42/proxy/compare/v1.1.16...v1.1.17
+[1.1.16]: https://github.com/theta42/proxy/compare/v1.1.15...v1.1.16
 [1.1.15]: https://github.com/theta42/proxy/compare/v1.1.14...v1.1.15
 [1.1.14]: https://github.com/theta42/proxy/compare/v1.1.13...v1.1.14
 [1.1.13]: https://github.com/theta42/proxy/compare/v1.1.12...v1.1.13

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proxy-api",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proxy-api",
-      "version": "1.1.16",
+      "version": "1.1.17",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-api",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "author": [
     {
       "name": "William Mantly",


### PR DESCRIPTION
Release 1.1.17.

Moves the wildcard sibling-parent fix (#170) into its own `1.1.17` CHANGELOG section — it is not part of the already-tagged `v1.1.16` — and bumps `nodejs/package.json` + lockfile to `1.1.17`.

### Fixed
- An existing single-label subdomain host (e.g. `sso.nl.wgnode.com`) could not be attached to a wildcard cert added later (e.g. `*.nl.wgnode.com`). `Host.lookUpWildcardParent()` now checks the wildcard-as-sibling position in addition to wildcard-as-child, so the edit form's "Parent Wildcard" option is offered for existing subdomains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)