### PR TITLE
Release v1.2.2: fix load-balancing crash (wrong lua-resty-balancer module)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ correspond to git tags (`vX.Y.Z`) and `nodejs/package.json`'s `version`.
 
 ## [Unreleased]
 
+## [1.2.2] - 2026-07-21
+
+### Fixed
+- Multi-target load balancing (added in 1.2.0) crashed every request to a load-balanced host: `ops/nginx_conf/targetinfo.lua` required a nonexistent `resty.balancer.round_robin` module. The `lua-resty-balancer` rock installed by the Dockerfile/`install.sh` doesn't provide that path — it provides `resty.roundrobin` (constructed as `roundrobin:new(nodes)`, not `:new()` + `:reinit(nodes)`). Fixed `targetinfo.lua` to use the real module and API; verified end-to-end that requests now round-robin across targets with no Lua errors.
+
 ## [1.2.1] - 2026-07-21
 
 ### Fixed

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proxy-api",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proxy-api",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-api",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": [
     {
       "name": "William Mantly",

--- a/ops/nginx_conf/targetinfo.lua
+++ b/ops/nginx_conf/targetinfo.lua
@@ -62,7 +62,7 @@ function M.get(ngx, domain, targetInfo)
 
     local json = require "cjson"
     local redis = require "resty.redis"
-    local round_robin = require "resty.balancer.round_robin"
+    local roundrobin = require "resty.roundrobin"
 
     if not domain then
         return nil, 499
@@ -114,12 +114,11 @@ function M.get(ngx, domain, targetInfo)
         local cache_key = domain .. "_" .. (res["updated_on"] or "0")
         
         if not M.host_balancers[domain] or M.host_balancers[domain].key ~= cache_key then
-            local b = round_robin:new()
             local nodes = {}
             for _, t in ipairs(target_list) do
                 nodes[t] = 1
             end
-            b:reinit(nodes)
+            local b = roundrobin:new(nodes)
             M.host_balancers[domain] = { b = b, key = cache_key }
         end
         


### PR DESCRIPTION
## Summary
Every request to a host with additional load-balancing targets (added in v1.2.0) 500'd: `ops/nginx_conf/targetinfo.lua` required `resty.balancer.round_robin`, which the actually-installed `lua-resty-balancer` rock does not provide. That rock provides `resty.roundrobin` instead, constructed as `roundrobin:new(nodes)` (not `:new()` + `:reinit(nodes)`). Fixed `targetinfo.lua` to use the real module/API.

## Test plan
- [x] `npm test` in `nodejs/` — 205/205 passing
- [x] Rebuilt the Docker image, confirmed `resty.roundrobin` loads and round-robins correctly via a standalone luajit script
- [x] Ran the built image end-to-end: created a host with two local backend targets, sent multiple requests through the proxy — all returned `200`, no Lua errors in the OpenResty log, and traffic was confirmed alternating between both backends via their access logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)