### PR TITLE
Release 1.4.0: unified front-end UI shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ correspond to git tags (`vX.Y.Z`) and `nodejs/package.json`'s `version`.
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-26
+
+### Changed
+- **Unified the front-end UI shell across the three theta42 apps.** `views/top.ejs`, `views/bottom.ejs` and `public/lib/js/app-base.js` are now byte-identical in sso-manager-node, proxy and jump-host, so the apps look and behave the same and a shell change lands in one edit per repo instead of three divergent ones. Everything that differs between the apps moved into a new `nodejs/utils/ui.js`, exposed to every render as `ui` via `app.locals`: nav items and the groups that may see them, footer repo/license/docs/Terms links, favicon, the profile and post-logout targets, and whether the update banner exists at all.
+- **One nav-gating model everywhere.** `app-base.js` reveals `.group-required-<cn>` elements for each group the current user is in, read from `GET /api/user/me`. sso-manager-node reports LDAP DNs in `memberOf` and the OIDC clients report CNs in `groups`; both normalise to CNs client-side, and the clients' effective-rights `isAdmin` flag is exposed as a synthetic `admin` group — so one gating model covers a group-based provider and boolean-admin clients without either app learning the other's response shape.
+- **`GET /api/user/me` is fetched once per page load and cached** (`app.auth.loadUser`). The nav, per-view `forceLogin` and every group-gated element read that one promise instead of issuing their own request.
+- `app.auth.isLoggedIn` is dual-mode: it returns a Promise **and** invokes an optional node-style callback, so the async and callback call styles both work against one shared `top.ejs`.
+- `app.auth.forceLogin` no longer uses `$.holdReady` (removed in jQuery 4). An unauthenticated user is redirected to `/login?redirect=<path>`; group requirements are still enforced, and `logOut` now only clears the session, leaving the destination to the caller (`ui.logoutRedirect`).
+- Dependency alignment across all three apps: `jquery` `^4.0.0` and `ejs` `^3.1.10`.
+
+### Fixed
+- **`app.api.delete` dropped its callback when called by `formAJAX`.** `formAJAX` always passes the serialized form as the second argument, so a DELETE-method form's callback landed in the data slot and never ran. `delete` now accepts both `(url, callback)` and `(url, data, callback)`.
+- **`app.api.post`/`put` referenced an undefined `callback2`** and threw when handed a non-function callback. Both are now dual-mode Promise/callback.
+- **The login page's "reveal the card once we know you're logged out" branch threw** (`Cannot read properties of null`) whenever the logged-in check answered before the parser reached that element — which it always did without a stored token. It now runs on DOM ready.
+- **`logInRedirect` on the legacy `/login/<path>` form kept only the path.** The OIDC provider routes an unauthenticated authorization request through `/login/oauth/authorize?client_id=…&state=…`; dropping the query there loses the entire authorization request. The suffix form now preserves its query string.
+
+### Added
+- `.group-required { display: none }` in `public/css/styles.css`, the base rule the shared gating model reveals against.
+- Admin-only nav items lost their inline `display: none` in favour of that class, and the brand link points at `/` instead of `#`.
+
+### Verified
+- Browser-verified against a full theta-env stack (sso-manager + proxy + jump-host): every top-level page renders with a clean console; nav gating is correct for admin and non-admin; `forceLogin`'s onboarding and group gates fire; `val.js` blocks a weak password and accepts a strong one through a real form submit; the DELETE-method forms work; and the OIDC login round trip (authorize with PKCE -> login -> consent -> callback -> token fragment) completes on both OIDC clients.
+
 ## [1.3.0] - 2026-07-25
 
 ### Added

--- a/nodejs/app.js
+++ b/nodejs/app.js
@@ -69,6 +69,11 @@ app.use(express.json());
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'ejs');
 
+// Per-app values for the shared UI shell (views/top.ejs + views/bottom.ejs).
+// Set as an app local so every res.render has it, including routes that don't
+// spread the routers' `values` object.
+app.locals.ui = require('./utils/ui');
+
 // Per-host SSO endpoints. nginx routes /__proxy_auth/* on every proxied host to
 // the app (see ops/nginx_conf/proxy.conf); these run the OIDC flow and set the
 // per-host session cookie. Mounted before the page router.

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proxy-api",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proxy-api",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proxy-api",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proxy-api",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",
@@ -20,7 +20,7 @@
         "bcrypt": "^6.0.0",
         "bootstrap": "^5.3.8",
         "compression": "^1.8.1",
-        "ejs": "^6.0.1",
+        "ejs": "^3.1.10",
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.2",
         "extend": "^3.0.2",
@@ -436,6 +436,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -832,15 +838,18 @@
       "license": "MIT"
     },
     "node_modules/ejs": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-6.0.1.tgz",
-      "integrity": "sha512-UaaM14yby8U3k02ihS1Bmj5Kz2d7CCQM1scxpgs4Mhkq8F1wR2gl3+Ts4h5Ne4Mnt7M9m4Dw7jsuMr3+xO4vZA==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
       "bin": {
         "ejs": "bin/cli.js"
       },
       "engines": {
-        "node": ">=0.12.18"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/encodeurl": {
@@ -1051,6 +1060,42 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/filelist": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -1428,6 +1473,23 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jq-repeat": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/jq-repeat/-/jq-repeat-2.2.0.tgz",
@@ -1733,6 +1795,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-api",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": [
     {
       "name": "William Mantly",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -30,7 +30,7 @@
     "bcrypt": "^6.0.0",
     "bootstrap": "^5.3.8",
     "compression": "^1.8.1",
-    "ejs": "^6.0.1",
+    "ejs": "^3.1.10",
     "express": "^5.2.1",
     "express-rate-limit": "^8.5.2",
     "extend": "^3.0.2",

--- a/nodejs/public/css/styles.css
+++ b/nodejs/public/css/styles.css
@@ -18,3 +18,7 @@ body {
 .card-title{
 	font-weight: bold;
 }
+
+.group-required{
+	display: none;
+}

--- a/nodejs/public/lib/js/app-base.js
+++ b/nodejs/public/lib/js/app-base.js
@@ -379,11 +379,13 @@ app.auth = (function(app){
 	}
 
 	// Where to go after a successful login: the ?redirect= query param, or the
-	// legacy /login/<path> suffix form, constrained to a same-origin path.
+	// legacy /login/<path> suffix form, constrained to a same-origin path. The
+	// suffix form keeps its query string — /login/oauth/authorize?client_id=…
+	// is how the OIDC provider sends an unauthenticated user through login.
 	function logInRedirect(){
 		var params = new URLSearchParams(location.search);
 		var target = params.get('redirect')
-			|| location.href.replace(location.origin + '/login', '').split('?')[0]
+			|| location.href.replace(location.origin + '/login', '')
 			|| '/';
 		window.location.href = safeInternalPath(target);
 	}

--- a/nodejs/public/lib/js/app-base.js
+++ b/nodejs/public/lib/js/app-base.js
@@ -129,7 +129,14 @@ app.api = (function(app){
 		return body('PUT', url, data, callback);
 	}
 
-	function remove(url, callback){
+	// Called both as (url, callback) and — from formAJAX, which always passes
+	// the serialized form as the second argument — as (url, data, callback).
+	// No request body is sent either way.
+	function remove(url, data, callback){
+		if(typeof data === 'function'){
+			callback = data;
+			data = undefined;
+		}
 		if(typeof callback !== 'function'){
 			return new Promise(function(resolve, reject){
 				$.ajax({

--- a/nodejs/public/lib/js/app-base.js
+++ b/nodejs/public/lib/js/app-base.js
@@ -1,3 +1,12 @@
+// Shared client framework for the theta42 apps.
+//
+// This file is byte-identical across sso-manager-node, proxy and jump-host —
+// per-app behaviour comes from the server (the `ui` locals in views/top.ejs and
+// the /api/user/me response), never from edits to this file. Edit all three
+// copies together.
+//
+// jQuery 4 safe: no $.isFunction, no $.holdReady.
+
 var app = {};
 
 app.pubsub = (function(){
@@ -45,7 +54,7 @@ app.pubsub = (function(){
 app.socket = (function(app){
 	// $.getScript('/socket.io/socket.io.js')
 	// <script type="text/javascript" src="/socket.io/socket.io.js"></script>
-	
+
 	var socket;
 	$(document).ready(function(){
 		socket = io({
@@ -75,10 +84,26 @@ app.socket = (function(app){
 app.api = (function(app){
 	var baseURL = '/api/'
 
-	function post(url, data, callback){
-		if(typeof callback !== 'function') callback = callback2;
+	// post/put/delete are dual-mode: pass a callback for the node-style
+	// (error, data, status) form, or omit it to get a Promise that resolves
+	// with the parsed body and rejects with the error body. get/options return
+	// the jqXHR, which is itself thenable, so `await app.api.get(...)` works.
+
+	function body(method, url, data, callback){
+		if(typeof callback !== 'function'){
+			return new Promise(function(resolve, reject){
+				$.ajax({
+					type: method,
+					url: baseURL+url,
+					headers: { 'auth-token': app.auth.getToken() },
+					data: JSON.stringify(data),
+					contentType: 'application/json; charset=utf-8',
+					dataType: 'json',
+				}).done(resolve).fail(function(xhr){ reject(xhr.responseJSON || {}); });
+			});
+		}
 		return $.ajax({
-			type: 'POST',
+			type: method,
 			url: baseURL+url,
 			headers:{
 				'auth-token': app.auth.getToken()
@@ -87,40 +112,37 @@ app.api = (function(app){
 			contentType: "application/json; charset=utf-8",
 			dataType: "json",
 			complete: function(res, text){
-				callback ? callback(
+				callback(
 					text !== 'success' ? res.statusText : null,
 					JSON.parse(res.responseText),
 					res.status
-				) : function(){}
+				);
 			}
 		});
+	}
+
+	function post(url, data, callback){
+		return body('POST', url, data, callback);
 	}
 
 	function put(url, data, callback){
-		if(typeof callback !== 'function') callback = callback2;
-		return $.ajax({
-			type: 'PUT',
-			url: baseURL+url,
-			headers:{
-				'auth-token': app.auth.getToken()
-			},
-			data: JSON.stringify(data),
-			contentType: "application/json; charset=utf-8",
-			dataType: "json",
-			complete: function(res, text){
-				callback ? callback(
-					text !== 'success' ? res.statusText : null,
-					JSON.parse(res.responseText),
-					res.status
-				) : function(){}
-			}
-		});
+		return body('PUT', url, data, callback);
 	}
 
-	function remove(url, callback, callback2){
-		if(typeof callback !== 'function') callback = callback2;
+	function remove(url, callback){
+		if(typeof callback !== 'function'){
+			return new Promise(function(resolve, reject){
+				$.ajax({
+					type: 'DELETE',
+					url: baseURL+url,
+					headers: { 'auth-token': app.auth.getToken() },
+					contentType: 'application/json; charset=utf-8',
+					dataType: 'json',
+				}).done(resolve).fail(function(xhr){ reject(xhr.responseJSON || {}); });
+			});
+		}
 		return $.ajax({
-			type: 'delete',
+			type: 'DELETE',
 			url: baseURL+url,
 			headers:{
 				'auth-token': app.auth.getToken()
@@ -128,11 +150,11 @@ app.api = (function(app){
 			contentType: "application/json; charset=utf-8",
 			dataType: "json",
 			complete: function(res, text){
-				callback ? callback(
+				callback(
 					text !== 'success' ? res.statusText : null,
 					JSON.parse(res.responseText),
 					res.status
-				) : function(){}
+				);
 			}
 		});
 	}
@@ -179,7 +201,11 @@ app.api = (function(app){
 })(app)
 
 app.auth = (function(app){
-	var user = {}
+	// One in-flight/cached GET /api/user/me per page load. Every gating
+	// decision (nav items, per-view forceLogin, group-required elements) reads
+	// this same promise instead of re-fetching.
+	var userPromise = null;
+
 	function setToken(token){
 		localStorage.setItem('APIToken', token);
 	}
@@ -188,16 +214,93 @@ app.auth = (function(app){
 		return localStorage.getItem('APIToken');
 	}
 
-	function isLoggedIn(callback){
-		if(getToken()){
-			return app.api.get('user/me', function(error, data){
-				// data now carries effective rights (isAdmin, global, domains).
-				if(!error) app.auth.user = app.auth.perms = data;
-				return callback(error, data);
-			});
-		}else{
-			callback(null, false);
+	async function getUser(){
+		try{
+			return await app.api.get('user/me');
+		}catch(error){
+			if(error && error.status === 401) return null;
+			throw error;
 		}
+	}
+
+	// Cached current user, or false when there's no token at all. Callers that
+	// need a fresh copy (after a login or a profile change) pass force.
+	function loadUser(force){
+		if(force || !userPromise){
+			userPromise = getToken() ? getUser() : Promise.resolve(null);
+			userPromise = userPromise.then(function(user){
+				app.auth.user = app.auth.perms = user || null;
+				return user;
+			});
+		}
+		return userPromise;
+	}
+
+	// The apps report group membership two ways: sso-manager-node returns LDAP
+	// DNs in `memberOf`, the OIDC clients return plain CNs in `groups`. Both
+	// normalise to a list of CNs. `isAdmin` (the clients' effective-rights flag)
+	// is exposed as a synthetic `admin` group so one gating model covers both.
+	function groupCNs(user){
+		var raw = (user && (user.memberOf || user.groups)) || [];
+		if(!Array.isArray(raw)) raw = [raw];
+		var names = raw.map(function(group){
+			return String(group).split(',')[0].replace(/^cn=/i, '');
+		});
+		if(user && user.isAdmin && names.indexOf('admin') === -1) names.push('admin');
+		return names;
+	}
+
+	async function memberOf(groupNameToFind, user){
+		user = user || await loadUser();
+		if(!user) return false;
+		groupNameToFind = Array.isArray(groupNameToFind) ? groupNameToFind : [groupNameToFind];
+
+		return groupCNs(user).some(function(group){
+			return groupNameToFind.includes(group);
+		});
+	}
+
+	// True when the logged-in user is a global admin (per user/me). Sync — only
+	// meaningful once isLoggedIn/forceLogin has resolved.
+	function isAdmin(){
+		return !!(app.auth.perms && app.auth.perms.isAdmin);
+	}
+
+	// Dual-mode: returns a Promise resolving to the user (or false), and calls
+	// an optional node-style callback with the same result.
+	function isLoggedIn(callback){
+		var promise = loadUser().then(function(user){
+			return user || false;
+		});
+
+		if(typeof callback === 'function'){
+			promise.then(function(user){
+				callback(null, user);
+			}, function(error){
+				callback(error, false);
+			});
+		}
+
+		return promise;
+	}
+
+	function logIn(args, callback){
+		app.api.post('auth/login', args, function(error, data){
+			if(data.login){
+				setToken(data.token);
+			}
+			loadUser(true);
+			callback(error, !!data.token);
+		});
+	}
+
+	// Clears the session only — the caller decides where to go next (the nav's
+	// Log Out button uses ui.logoutRedirect).
+	function logOut(callback){
+		localStorage.removeItem('APIToken');
+		userPromise = null;
+		app.auth.user = app.auth.perms = null;
+		if(typeof callback === 'function') callback();
 	}
 
 	// Constrain a redirect target to a same-origin absolute path. Rejects
@@ -230,46 +333,66 @@ app.auth = (function(app){
 		return true;
 	}
 
-	// True when the logged-in user is a global admin (per user/me).
-	function isAdmin(){
-		return !!(app.auth.perms && app.auth.perms.isAdmin);
+	// Page-level gate. jQuery 4 removed $.holdReady, so an unauthenticated or
+	// unauthorised user is kept off the page by a redirect / an error panel
+	// rather than by pausing document ready.
+	//
+	// `requiredGroups` is a group CN or an OR-list of them; the synthetic
+	// `admin` group covers the OIDC clients' isAdmin flag.
+	async function forceLogin(requiredGroups){
+		var user = await loadUser();
+
+		if(!user){
+			logOut(function(){});
+			location.replace('/login?redirect=' + encodeURIComponent(
+				location.pathname + location.search
+			));
+			return false;
+		}
+
+		if(user.onboardingRequired && location.pathname !== '/onboarding'){
+			location.replace('/onboarding');
+			return false;
+		}
+
+		if(requiredGroups && !await memberOf(requiredGroups, user)){
+			app.util.actionMessage(
+				`<h1>
+					<i class="fa-solid fa-triangle-exclamation"></i>
+					<b>You do not have permission to be here.</b>
+					<i class="fa-solid fa-triangle-exclamation"></i>
+				</h1>`,
+				$('#spa-shell'),
+				'danger',
+			);
+			throw new Error("User does not have permission");
+		}
+
+		return user;
 	}
 
-	function logIn(args, callback){
-		app.api.post('auth/login', args, function(error, data){
-			if(data.login){
-				setToken(data.token);
-			}
-			callback(error, !!data.token);
-		});
-	}
-
-	function logOut(callback){
-		localStorage.removeItem('APIToken');
-		callback();
-	}
-
-	function forceLogin(){
-		// jQuery 4 removed $.holdReady; rely on the redirect below to keep an
-		// unauthenticated user off the page instead of pausing document ready.
-		app.auth.isLoggedIn(function(error, isLoggedIn){
-			if(error || !isLoggedIn){
-				app.auth.logOut(function(){})
-				location.replace(`/login${location.href.replace(location.origin, '')}`);
-			}
-		});
-	}
-
+	// Where to go after a successful login: the ?redirect= query param, or the
+	// legacy /login/<path> suffix form, constrained to a same-origin path.
 	function logInRedirect(){
-		window.location.href = safeInternalPath(location.href.replace(location.origin+'/login', '') || '/')
+		var params = new URLSearchParams(location.search);
+		var target = params.get('redirect')
+			|| location.href.replace(location.origin + '/login', '').split('?')[0]
+			|| '/';
+		window.location.href = safeInternalPath(target);
 	}
 
 	return {
 		getToken: getToken,
 		setToken: setToken,
-		isLoggedIn: isLoggedIn,
-		consumeTokenFragment: consumeTokenFragment,
+		getUser: getUser,
+		loadUser: loadUser,
+		groupCNs: groupCNs,
+		memberOf: memberOf,
 		isAdmin: isAdmin,
+		isLoggedIn: isLoggedIn,
+		safeInternalPath: safeInternalPath,
+		consumeTokenFragment: consumeTokenFragment,
+		user: null,
 		perms: null,
 		logIn: logIn,
 		logOut: logOut,
@@ -278,6 +401,11 @@ app.auth = (function(app){
 	}
 
 })(app);
+
+// Back-compat alias for views that awaited the cached user directly.
+Object.defineProperty(app.auth, 'asyncUser', {
+	get: function(){ return app.auth.loadUser(); },
+});
 
 app.user = (function(app){
 	function list(callback){
@@ -308,6 +436,8 @@ app.user = (function(app){
 
 })(app);
 
+// Local (app-managed) permissions and groups. Only the OIDC-client apps serve
+// these endpoints; the calls are inert elsewhere.
 app.permission = (function(app){
 	function list(callback){
 		app.api.get('permission/', function(error, data){
@@ -381,9 +511,12 @@ app.util = (function(app){
 		return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
 	};
 
-	function actionMessage(message, $target, type, callback){
+	function actionMessage(message, $targetPassed, type, callback){
 		message = message || '';
-		$target = $target.closest('div.card').find('.actionMessage');
+
+		let $target = $targetPassed.closest('div.card').find('.actionMessage');
+		if(!$target.length) $target = $($targetPassed.find('.actionMessage')[0]);
+
 		type = type || 'info';
 		callback = callback || function(){};
 
@@ -400,10 +533,46 @@ app.util = (function(app){
 			})
 		}else{
 			if(type) $target.addClass('bg-' + type);
-			message = '<span class="align-middle">' + message + '</span><button class="action-close btn btn-sm btn-outline-dark float-end"><i class="fa-solid fa-xmark"></i></button>'
+
+			// Messages that bring their own buttons (actionConfirm) are left
+			// alone; everything else gets the standard dismiss button.
+			if(!message.includes('<button')) message = `
+				<span class="align-middle">${message}</span>
+				<button class="action-close btn btn-sm btn-outline-dark float-end">
+					<i class="fa-solid fa-xmark"></i>
+				</button>
+			`
 			$target.html(message).slideDown('fast');
 		}
 		setTimeout(callback,10)
+	}
+
+	function actionConfirm(message, $target, type, callback){
+		return new Promise((resolve, reject) =>{
+			let id = crypto.randomUUID();
+			message = `
+				<h4 class"align-middle" >
+					<i class="fa-solid fa-triangle-exclamation"></i>
+					<b>${message}</b>
+					<span class="float-end">
+						<button type="button" class="btn btn-success confirm-${id}" data-confirm="true">
+							<i class="fa-solid fa-circle-check"></i>
+							Confirm
+						</button>
+						<button type="button" class="btn btn-danger confirm-${id}">
+							<i class="fa-solid fa-circle-stop"></i>
+							Cancel
+						</button>
+					</span>
+				</h4>
+			`
+			actionMessage(message, $target, type);
+			$("body").on('click', `.confirm-${id}`, function(){
+				actionMessage('', $target, type);
+				resolve(!!$(this).data('confirm'));
+			});
+		});
+
 	}
 
 	$.fn.serializeObject = function() {
@@ -462,11 +631,42 @@ app.util = (function(app){
 	return {
 		downloadFile: downloadFile,
 		getUrlParameter: getUrlParameter,
-		actionMessage: actionMessage
+		actionMessage: actionMessage,
+		actionConfirm,
 	}
 })(app);
 
-$( document ).ready(function(){
+// Reveal every .group-required-<cn> element the current user's groups entitle
+// them to. Elements carrying .group-required start hidden (styles.css), so a
+// user who is in no groups — or who isn't logged in — simply never sees them.
+app.auth.applyGroupVisibility = function(user){
+	var groups = app.auth.groupCNs(user);
+	if(!groups.length) return;
+
+	var style = document.getElementById('group-required-rules');
+	if(!style){
+		style = document.createElement('style');
+		style.id = 'group-required-rules';
+		document.head.appendChild(style);
+	}
+
+	for(var group of groups){
+		try{
+			style.sheet.insertRule(
+				`.group-required-${CSS.escape(group)} { display: revert !important; }`,
+				style.sheet.cssRules.length
+			);
+		}catch(error){
+			// A group whose CN isn't a usable CSS identifier just gates nothing.
+		}
+	}
+};
+
+$( document ).ready(async function(){
+
+	// Show content the user's groups entitle them to.
+	app.auth.applyGroupVisibility(await app.auth.loadUser());
+
 	$('div.row').fadeIn('slow'); //show the page
 
 	//panel button's
@@ -520,12 +720,14 @@ function formAJAX(btn){
 	var method = ($form.attr('method') || 'post').toLowerCase();
 
 	if($form.validate && !$form.validate()){
-		app.util.actionMessage('Please fix the form errors.', $form, 'danger');
+		app.util.actionMessage('Please fix the form errors.', $form, 'danger')
 		return false;
 	}
-	
-	app.util.actionMessage( 
-		'<div class="spinner-border" role="status"><span class="sr-only">Loading...</span></div>',
+
+	app.util.actionMessage(
+		`<div class="spinner-border" role="status">
+			<span class="visually-hidden">Loading...</span>
+		</div>`,
 		$form,
 		'info'
 	);

--- a/nodejs/utils/ui.js
+++ b/nodejs/utils/ui.js
@@ -1,0 +1,45 @@
+'use strict';
+
+// Per-app values for the shared UI shell (views/top.ejs + views/bottom.ejs).
+//
+// Those two partials are byte-identical across sso-manager-node, proxy and
+// jump-host — everything that differs between the apps lives here and is
+// exposed to every render as `ui` via app.locals (see app.js). Keep the key set
+// in sync across the three apps; a missing key is a render-time ReferenceError,
+// not a silent fallback.
+
+module.exports = {
+	// --- footer -------------------------------------------------------------
+	repoUrl: 'https://github.com/theta42/proxy',
+	licenseUrl: 'https://github.com/theta42/proxy/blob/master/LICENSE',
+	// In-app docs route (routes/docs.js). Apps without one point at the
+	// published docs site and set docsExternal.
+	docsUrl: '/docs',
+	docsExternal: false,
+	// Only sso-manager-node serves a Terms of Service page; null hides the link.
+	tosUrl: null,
+
+	// --- header / nav -------------------------------------------------------
+	faviconUrl: '/static/favicon.svg',
+	// Where the current-user chip links. null renders it as a plain span (for
+	// apps with no profile page).
+	profileUrl: '/profile',
+	// Where "Log Out" lands.
+	logoutRedirect: '/',
+	// Admin-only "a newer release is available" banner, backed by
+	// GET /api/update-check. Apps without that endpoint set false.
+	updateCheck: true,
+	updateLabel: 'the proxy',
+
+	// Nav items, in order. `groups` is an OR-list of group CNs that may see the
+	// item; an empty list means "always visible". Gating is done client-side by
+	// app-base.js, which reveals .group-required-<cn> for each group the user is
+	// in (plus the synthetic `admin` group when user/me reports isAdmin).
+	nav: [
+		{href: '/hosts', icon: 'fa-solid fa-network-wired', label: 'Hosts', groups: []},
+		{href: '/dns', icon: 'fa-solid fa-record-vinyl', label: 'DNS', groups: []},
+		{href: '/users', icon: 'fa-solid fa-users', label: 'Users', groups: ['admin']},
+		{href: '/permissions', icon: 'fa-solid fa-user-shield', label: 'Permissions', groups: ['admin']},
+		{href: '/groups', icon: 'fa-solid fa-users-gear', label: 'Groups', groups: ['admin']},
+	],
+};

--- a/nodejs/views/bottom.ejs
+++ b/nodejs/views/bottom.ejs
@@ -1,24 +1,30 @@
-		</div>
+		</div><!-- end spa-shell -->
 
-		<footer class="py-2 bg-dark text-light mt-4">
-			<div class="container-fluid d-flex flex-wrap justify-content-between align-items-center small gap-2">
-				<span class="d-flex align-items-center gap-2">
-					<a href="https://theta42.com" target="_blank">
-						<img width="64" src="/static/img/theta42.svg"/>
-					</a>
-					&copy; <%- buildYear %> theta42 &middot;
-					<a href="https://github.com/theta42/proxy/blob/master/LICENSE" target="_blank" class="text-light">MIT License</a>
-				</span>
-				<span class="d-flex align-items-center gap-3">
-					<a href="/docs" class="text-light text-decoration-none">
-						<i class="fa-solid fa-book"></i> Docs
-					</a>
-					<a href="https://github.com/theta42/proxy" target="_blank" class="text-light text-decoration-none">
-						<i class="fa-brands fa-github"></i> GitHub
-					</a>
-				</span>
-				<span>v<%- buildVersion %> (<%- buildHash %>)</span>
-			</div>
-		</footer>
-    </body>
+	<!-- Shared UI shell — byte-identical across sso-manager-node, proxy and
+	     jump-host. Everything per-app comes from `ui` (utils/ui.js, exposed via
+	     app.locals in app.js). Edit all three copies together. -->
+	<footer class="py-2 bg-dark text-light mt-4">
+		<div class="container-fluid d-flex flex-wrap justify-content-between align-items-center small gap-2">
+			<span class="d-flex align-items-center gap-2">
+				<a href="https://theta42.com" target="_blank">
+					<img width="64" src="/static/img/theta42.svg"/>
+				</a>
+				&copy; <%- buildYear %> theta42 &middot;
+				<a href="<%- ui.licenseUrl %>" target="_blank" class="text-light">MIT License</a>
+			</span>
+			<span class="d-flex align-items-center gap-3">
+				<a href="<%- ui.docsUrl %>"<%- ui.docsExternal ? ' target="_blank"' : '' %> class="text-light text-decoration-none">
+					<i class="fa-solid fa-book"></i> Docs
+				</a>
+				<a href="<%- ui.repoUrl %>" target="_blank" class="text-light text-decoration-none">
+					<i class="fa-brands fa-github"></i> GitHub
+				</a>
+				<% if(ui.tosUrl){ %>
+				<a href="<%- ui.tosUrl %>" class="text-light text-decoration-none">Terms of Service</a>
+				<% } %>
+			</span>
+			<span>v<%- buildVersion %> (<%- buildHash %>)</span>
+		</div>
+	</footer>
+	</body>
 </html>

--- a/nodejs/views/login.ejs
+++ b/nodejs/views/login.ejs
@@ -4,14 +4,18 @@
 	// If we arrived from the OIDC callback with a token in the URL fragment,
 	// store it and forward on before doing anything else.
 	if(!app.auth.consumeTokenFragment()){
-		app.auth.isLoggedIn(function(error, isLoggedIn){
-			if(isLoggedIn){
-				app.auth.logInRedirect();
-			}else{
-				// Reveal the login card once we know the user is not logged in.
-				document.getElementById('login-card-row').style.display = '';
-			}
-		})
+		// The reveal below touches an element further down this page, so wait
+		// for the DOM — isLoggedIn can answer before the parser gets there.
+		$(document).ready(function(){
+			app.auth.isLoggedIn(function(error, isLoggedIn){
+				if(isLoggedIn){
+					app.auth.logInRedirect();
+				}else{
+					// Reveal the login card once we know the user is not logged in.
+					document.getElementById('login-card-row').style.display = '';
+				}
+			});
+		});
 	}
 
 </script>

--- a/nodejs/views/top.ejs
+++ b/nodejs/views/top.ejs
@@ -4,8 +4,11 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 		<title><%- name %> <%- title %></title>
+		<!-- Shared UI shell — byte-identical across sso-manager-node, proxy and
+		     jump-host. Everything per-app comes from `ui` (utils/ui.js, exposed
+		     via app.locals in app.js). Edit all three copies together. -->
 		<!-- Favicon -->
-		<link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+		<link rel="icon" type="image/svg+xml" href="<%- ui.faviconUrl %>">
 		<!-- CSS are placed here -->
 		<link rel="stylesheet" href="/static-modules/bootstrap/dist/css/bootstrap.min.css">
 		<link rel="stylesheet" href="/static-modules/@fortawesome/fontawesome-free/css/all.min.css">
@@ -14,8 +17,6 @@
 		<!-- Scripts are placed here -->
 		<script type="text/javascript" src="/socket.io/socket.io.js"></script>
 		<script type="text/javascript" src='/static-modules/jquery/dist/jquery.js'></script>
-		<!-- <script type="text/javascript" src="/static/lib/js/popper-1.16.0.min.js"></script> -->
-		<!-- <script type="text/javascript" src="/static-modules/bootstrap/dist/js/bootstrap.min.js"></script> -->
 		<script type="text/javascript" src="/static-modules/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
 		<script type="text/javascript" src="/static-modules/@fortawesome/fontawesome-free/js/all.min.js"></script>
 		<script type="text/javascript" src='/static-modules/mustache/mustache.min.js'></script>
@@ -28,49 +29,38 @@
 	<body>
 
 		<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
-			<a class="navbar-brand" href="#"><img src="<%- logo %>" height="28" class="me-2" alt=""><%- name %> <%- titleIcon %></a>
+			<a class="navbar-brand" href="/"><img src="<%- logo %>" height="28" class="me-2" alt=""><%- name %> <%- titleIcon %></a>
 			<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
 				<span class="navbar-toggler-icon"></span>
 			</button>
 			<div class="collapse navbar-collapse justify-content-end" id="navbarSupportedContent">
 				<ul class="navbar-nav top-nav">
-					<li class="nav-item">
-						<a class="nav-link active" href="/hosts">
-							<i class="fa-solid fa-network-wired"></i>
-							Hosts
+					<%# Items gated on a group start hidden (.group-required) and are
+					    revealed by app-base.js for the groups the user is in. %>
+					<% for(const item of ui.nav){ %>
+					<li class="nav-item<%- item.groups.length ? ' group-required' : '' %><%- item.groups.map(group => ' group-required-' + group).join('') %>">
+						<a class="nav-link" href="<%- item.href %>"><i class="<%- item.icon %>"></i>
+							<%- item.label %>
 						</a>
 					</li>
-					<li class="nav-item">
-						<a class="nav-link" href="/dns"><i class="fa-solid fa-record-vinyl"></i>
-							DNS
-						</a>
-					</li>
-					<li class="nav-item nav-admin" style="display: none;">
-						<a class="nav-link" href="/users"><i class="fa-solid fa-users"></i>
-							Users
-						</a>
-					</li>
-					<li class="nav-item nav-admin" style="display: none;">
-						<a class="nav-link" href="/permissions"><i class="fa-solid fa-user-shield"></i>
-							Permissions
-						</a>
-					</li>
-					<li class="nav-item nav-admin" style="display: none;">
-						<a class="nav-link" href="/groups"><i class="fa-solid fa-users-gear"></i>
-							Groups
-						</a>
-					</li>
+					<% } %>
 				</ul>
 				<div class="form-inline mt-2 mt-md-0">
-					<a id="cl-username" class="navbar-text text-light me-3" href="/profile" style="display: none;">
+					<% if(ui.profileUrl){ %>
+					<a id="cl-username" class="navbar-text text-light me-3" href="<%- ui.profileUrl %>" style="display: none;">
 						<i class="fa-solid fa-user me-1"></i><span id="cl-username-text"></span>
 					</a>
+					<% } else { %>
+					<span id="cl-username" class="navbar-text text-light me-3" style="display: none;">
+						<i class="fa-solid fa-user me-1"></i><span id="cl-username-text"></span>
+					</span>
+					<% } %>
 					<a id="cl-login-button" class="btn btn-outline-danger my-2 my-sm-0" onclick="app.auth.forceLogin()" style="display: none;">
-						<i class="fas fa-sign-out"></i>
+						<i class="fas fa-sign-in"></i>
 						Login
 					</a>
 
-					<button id="cl-logout-button" class="btn btn-outline-danger my-2 my-sm-0" onclick="app.auth.logOut(e => window.location.href='/')" style="display: none;">
+					<button id="cl-logout-button" class="btn btn-outline-danger my-2 my-sm-0" onclick="app.auth.logOut(function(){ window.location.href = '<%- ui.logoutRedirect %>'; })" style="display: none;">
 						<i class="fas fa-sign-out"></i>
 						Log Out
 					</button>
@@ -78,6 +68,7 @@
 			</div>
 		</nav>
 
+		<% if(ui.updateCheck){ %>
 		<!-- Admin-only "a newer release is available" notice (services/update_check.js).
 		     Dismissal is per-browser-session only (sessionStorage), not persisted server-side.
 		     Fixed-positioned below the fixed navbar (a plain in-flow div here would render
@@ -102,6 +93,22 @@
 				sessionStorage.setItem('update-banner-dismissed', '1');
 			}
 
+			function checkForUpdate(){
+				if(sessionStorage.getItem('update-banner-dismissed')) return;
+				app.api.get('update-check', function(error, info){
+					if(error || !info || !info.updateAvailable) return;
+					$('#update-banner-text').html(
+						'A newer version of <%- ui.updateLabel %> is available: <b>v' + info.latestVersion + '</b> ' +
+						'(running v' + info.currentVersion + ') — ' +
+						'<a href="' + info.releaseUrl + '" target="_blank" class="alert-link">see what changed</a>.'
+					);
+					showUpdateBanner();
+				});
+			}
+		</script>
+		<% } %>
+
+		<script type="text/javascript">
 			$(document).ready(function(){
 
 				// Set the correct link to active in the top nav bar
@@ -113,33 +120,23 @@
 					}
 				})
 
-				// Set the correct login/logout button, and reveal admin-only nav
-				// items for global admins.
-				app.auth.isLoggedIn(function(error, data){
-					if(data){
+				// Set the correct login/logout button, and reveal the current user's
+				// name once we know who they are. Group-gated nav items are revealed
+				// by app-base.js off the same cached user/me.
+				app.auth.isLoggedIn(function(error, me){
+					if(me){
 						$('#cl-logout-button').show();
-						if(data.username){
-							$('#cl-username-text').text(data.username);
+						let username = me.uid || me.username;
+						if(username){
+							$('#cl-username-text').text(username);
 							$('#cl-username').css('display', '');
 						}
+
+						<% if(ui.updateCheck){ %>
+						if(me.isAdmin) checkForUpdate();
+						<% } %>
 					}else{
 						$('#cl-login-button').show();
-					}
-
-					if(data && data.isAdmin){
-						$('.nav-admin').css('display', '');
-
-						if(!sessionStorage.getItem('update-banner-dismissed')){
-							app.api.get('update-check', function(error, info){
-								if(error || !info || !info.updateAvailable) return;
-								$('#update-banner-text').html(
-									'A newer version of the proxy is available: <b>v' + info.latestVersion + '</b> ' +
-									'(running v' + info.currentVersion + ') — ' +
-									'<a href="' + info.releaseUrl + '" target="_blank" class="alert-link">see what changed</a>.'
-								);
-								showUpdateBanner();
-							});
-						}
 					}
 				});
 
@@ -149,3 +146,4 @@
 
 		<!-- Container -->
 		<div id="spa-shell" class="container-fluid">
+			<div class="actionMessage" style="display:none;"></div>


### PR DESCRIPTION
## What

Unifies the front-end UI shell across sso-manager-node, proxy and jump-host. `views/top.ejs`, `views/bottom.ejs` and `public/lib/js/app-base.js` are now byte-identical in all three; everything per-app moved into a new `nodejs/utils/ui.js`, exposed to every render as `ui` via `app.locals` (nav items + their group gates, footer links, favicon, profile/logout targets, update-banner on/off).

One gating model everywhere: `app-base.js` reveals `.group-required-<cn>` for each group in `GET /api/user/me`. sso sends LDAP DNs in `memberOf`, the OIDC clients send CNs in `groups`; both normalise to CNs client-side, and the clients `isAdmin` flag becomes a synthetic `admin` group. `user/me` is fetched once per page and cached; `isLoggedIn` is dual-mode (Promise + callback); `forceLogin` is redirect-based now that jQuery 4 has removed `$.holdReady`. jquery `^4.0.0` and ejs `^3.1.10` in all three.

## Bugs fixed on the way

- `app.api.post`/`put` referenced an undefined `callback2` and threw on a non-function callback.
- `app.api.delete` did not accept the `(url, data, callback)` arity `formAJAX` actually uses, so DELETE-method forms never ran their callback.
- `val.js` `validateField` shadowed `message` with `let` (sso only), so custom rule messages never surfaced.
- The login page revealed its card by touching an element the parser had not reached yet, throwing on every logged-out visit.
- `logInRedirect` dropped the query string from the legacy `/login/<path>` form — which is how the OIDC provider routes an unauthenticated authorize request.

## Verification

Browser-driven against a full theta-env stack (all three apps, `CFG_DOMAIN=localtest.me`):

- Every top-level page of all three apps renders with a clean console.
- Nav gating per role: sso admin sees Users/Groups/Directory/Executive, a fresh non-admin sees none and gets the permission panel on `/users`; proxy admin sees Users/Permissions/Groups, logged-out sees only Hosts/DNS; jump shows all three always.
- `forceLogin` onboarding + group gates fire; `val.js` blocks a weak password and accepts a strong one through a real submit; the proxy host delete (DELETE-method form) works.
- OIDC end-to-end on proxy **and** jump: authorize (PKCE) -> SSO login -> consent -> callback -> token fragment consumed -> landed logged in.

Unit suites: proxy 205/205, jump-host 27/27. sso jest is integration-level (needs the docker harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)