### PR TITLE
Remove native confirm() calls in revokeToken/rotateToken

### DIFF
--- a/nodejs/views/profile.ejs
+++ b/nodejs/views/profile.ejs
@@ -178,16 +178,18 @@
 		});
 	}
 
-	function revokeToken(id, name, btn){
-		if(!confirm('Revoke API token "' + name + '"? It stops working immediately.')) return;
+	async function revokeToken(id, name, btn){
+		const ok = await app.messages.confirm('Revoke API token "' + name + '"? It stops working immediately.', $(btn).closest('.card'), 'danger');
+		if(!ok) return;
 		app.apiToken.remove({id: id}, function(error, data){
 			if(error) return app.messages.action(error, $(btn).closest('.card'), 'danger');
 			$.scope.apiTokenCard.remove('id', id);
 		});
 	}
 
-	function rotateToken(id, name, btn){
-		if(!confirm('Rotate API token "' + name + '"? The old token stops working immediately.')) return;
+	async function rotateToken(id, name, btn){
+		const ok = await app.messages.confirm('Rotate API token "' + name + '"? The old token stops working immediately.', $(btn).closest('.card'), 'warning');
+		if(!ok) return;
 		app.apiToken.rotate({id: id}, function(error, data){
 			if(error) return app.messages.action(error, $(btn).closest('.card'), 'danger');
 			showSecret(data.token);


### PR DESCRIPTION
## Summary
Native `confirm()` blocks browser automation entirely (found live, mid browser-test, on sso-manager-node's equivalent secret-rotate flow). `revokeToken`/`rotateToken` already receive `btn`, whose `.closest('.card')` is already the error-path target — `app.messages.confirm` reuses it.

## Test plan
- [x] `grep` confirms zero native `alert(`/`confirm(`/`prompt(` remain in this repo.
- [x] `ejs.compile()` passes on the modified view.
- [x] `npm run test:unit` — 175/175 passing.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>