### PR TITLE
Fix HTML-escaped loading indicator in formAJAX

### DIFF
--- a/nodejs/public/lib/js/app-base.js
+++ b/nodejs/public/lib/js/app-base.js
@@ -679,13 +679,10 @@ function formAJAX(btn){
 		return false;
 	}
 
-	app.messages.action(
-		`<div class="spinner-border" role="status">
-			<span class="visually-hidden">Loading...</span>
-		</div>`,
-		$form,
-		'info'
-	);
+	// Plain text: app.messages.action HTML-escapes its message (by design,
+	// see @simpleworkjs/frontend), so raw markup like a spinner <div> would
+	// render literally instead of as an element.
+	app.messages.action('Saving…', $form, 'info');
 
 	app.api[method]($form.attr('action'), formData, function(error, data){
 		app.messages.action(data.message, $form, error ? 'danger' : 'success'); //re-populate table


### PR DESCRIPTION
Same fix as theta42/sso-manager-node's companion PR — formAJAX's loading indicator passed raw spinner HTML to app.messages.action, which HTML-escapes its message by design. Replaced with plain text.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>