### PR TITLE
v1.13.0: load secrets from OpenBao at boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ correspond to git tags (`vX.Y.Z`) and `nodejs/package.json`'s `version`.
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-08-01
+
+### Changed
+- **Secrets now load from OpenBao at boot** via
+  [@simpleworkjs/bao-conf](https://simpleworkjs.github.io/bao-conf/), which
+  deep-merges `secret/proxy/conf` over the file-loaded config. The proxy
+  authenticates to OpenBao with a scoped `VAULT_TOKEN` (policy `proxy` —
+  read-only on its own path), never the root token. Because the OIDC
+  `clientSecret` is captured at require time inside `createOidcClient` (during
+  `require('../models')`, which `require('../app')` triggers transitively),
+  `bin/www` now defers `require('../app')` until after `bao-conf.init()`
+  resolves. Fail-soft: if OpenBao is unreachable, boot continues from
+  `CONF_SECRETS`. The `config/proxy-secrets.js` file is now an operator-edit
+  seed artifact (gitignored); OpenBao is authoritative. See theta-env's
+  [Secrets docs](https://theta42.github.io/theta-env/secrets/).
+- Bumped package version to track the release tag.
+
 ## [1.12.1] - 2026-08-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -162,6 +162,23 @@ docker compose exec proxy tail -f /var/log/nginx/error.log
 docker compose logs --tail=200 --since=10m proxy
 ```
 
+## Secrets
+
+Secrets are loaded from **OpenBao** at boot via
+[@simpleworkjs/bao-conf](https://simpleworkjs.github.io/bao-conf/), which
+deep-merges `secret/proxy/conf` over the file-loaded config. The proxy's OIDC
+`clientSecret` is captured at require time (inside `createOidcClient` during
+`require('../models')`), so `bin/www` runs `bao-conf.init()` **before**
+`require('../app')` (which transitively loads models). Fail-soft: if OpenBao is
+unreachable, boot continues from `CONF_SECRETS`. The proxy authenticates to
+OpenBao with the scoped `VAULT_TOKEN` (env, policy `proxy` — read only
+`secret/proxy/conf`), never the root token.
+
+The `config/proxy-secrets.js` file is an operator-edit seed artifact
+(gitignored); the bootstrap writes the generated OAuth client creds into
+OpenBao, which is authoritative. For the full architecture see theta-env's
+**[Secrets docs](https://theta42.github.io/theta-env/secrets/)**.
+
 ## Manual Installation
 
 For manual installation or other distributions, see the detailed steps below.

--- a/nodejs/bin/www
+++ b/nodejs/bin/www
@@ -4,34 +4,91 @@
  * Module dependencies.
  */
 
-var app = require('../app');
-var debug = require('debug')('proxy-api:server');
-var http = require('http');
 const conf = require('@simpleworkjs/conf');
+const debug = require('debug')('proxy-api:server');
+const http = require('http');
 
-/**
- * Get port from environment and store in Express.
- */
+// @simpleworkjs/conf loads ./config/proxy-secrets.js synchronously, then
+// @simpleworkjs/bao-conf deep-merges secret/proxy/conf from OpenBao over it.
+// The OIDC clientSecret is captured at require time inside models (via
+// createOidcClient), and require('../app') transitively loads models, so the
+// OpenBao fetch MUST resolve before require('../app'). Fail-soft: if OpenBao
+// is unreachable, init() leaves conf as the file-loaded fallback and boot
+// continues from ./config/proxy-secrets.js.
+require('@simpleworkjs/bao-conf').init({ path: 'proxy', conf }).then(() => {
+  var app = require('../app');   // models + createOidcClient now see merged conf
 
-var port = normalizePort(process.env.NODE_PORT || conf.port || '3000');
-app.set('port', port);
+  /**
+   * Get port from environment and store in Express.
+   */
 
-/**
- * Create HTTP server.
- */
+  var port = normalizePort(process.env.NODE_PORT || conf.port || '3000');
+  app.set('port', port);
 
-var server = http.createServer(app);
+  /**
+   * Create HTTP server.
+   */
 
-var io = require('socket.io')(server);
-app.io = io;
+  var server = http.createServer(app);
 
-/**
- * Listen on provided port, on all network interfaces.
- */
+  var io = require('socket.io')(server);
+  app.io = io;
 
-server.listen(port);
-server.on('error', onError);
-server.on('listening', onListening);
+  /**
+   * Listen on provided port, on all network interfaces.
+   */
+
+  server.listen(port);
+  server.on('error', onError);
+  server.on('listening', onListening);
+
+  /**
+   * Event listener for HTTP server "error" event.
+   */
+
+  function onError(error) {
+    if (error.syscall !== 'listen') {
+      throw error;
+    }
+
+    var bind = typeof port === 'string'
+      ? 'Pipe ' + port
+      : 'Port ' + port;
+
+    // handle specific listen errors with friendly messages
+    switch (error.code) {
+      case 'EACCES':
+        console.error(bind + ' requires elevated privileges');
+        process.exit(1);
+        break;
+      case 'EADDRINUSE':
+        console.error(bind + ' is already in use');
+        process.exit(1);
+        break;
+      default:
+        throw error;
+    }
+  }
+
+  /**
+   * Event listener for HTTP server "listening" event.
+   */
+
+  function onListening() {
+    var addr = server.address();
+    var bind = typeof addr === 'string'
+      ? 'pipe ' + addr
+      : 'port ' + addr.port;
+    console.log('Listening on ' + bind);
+
+    for(let listener of app.onListen){
+      listener()
+    }
+  }
+}).catch(err => {
+  console.error('boot failed:', err);
+  process.exit(1);
+});
 
 /**
  * Normalize a port into a number, string, or false.
@@ -51,48 +108,4 @@ function normalizePort(val) {
   }
 
   return false;
-}
-
-/**
- * Event listener for HTTP server "error" event.
- */
-
-function onError(error) {
-  if (error.syscall !== 'listen') {
-    throw error;
-  }
-
-  var bind = typeof port === 'string'
-    ? 'Pipe ' + port
-    : 'Port ' + port;
-
-  // handle specific listen errors with friendly messages
-  switch (error.code) {
-    case 'EACCES':
-      console.error(bind + ' requires elevated privileges');
-      process.exit(1);
-      break;
-    case 'EADDRINUSE':
-      console.error(bind + ' is already in use');
-      process.exit(1);
-      break;
-    default:
-      throw error;
-  }
-}
-
-/**
- * Event listener for HTTP server "listening" event.
- */
-
-function onListening() {
-  var addr = server.address();
-  var bind = typeof addr === 'string'
-    ? 'pipe ' + addr
-    : 'port ' + addr.port;
-  console.log('Listening on ' + bind);
-
-  for(let listener of app.onListen){
-    listener()
-  }
 }

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -12,6 +12,7 @@
         "@fortawesome/fontawesome-free": "^7.3.0",
         "@popperjs/core": "^2.11.8",
         "@simpleworkjs/app-stack": "^1.0.0",
+        "@simpleworkjs/bao-conf": "^1.0.0",
         "@simpleworkjs/conf": "^1.2.0",
         "@simpleworkjs/frontend": "^0.2.7",
         "@simpleworkjs/ldap": "^1.0.0",
@@ -292,6 +293,18 @@
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@simpleworkjs/bao-conf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@simpleworkjs/bao-conf/-/bao-conf-1.0.0.tgz",
+      "integrity": "sha512-HxB2ohFuDKbwTfNh5dXCot0dd6qoP+3Ebz1xKH0eOhKNVNMjHU1p7XZv2VTe+VnHn+DV22Eh8lAgWxnX/pkXUw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-api",
-  "version": "1.9.0",
+  "version": "1.13.0",
   "author": [
     {
       "name": "William Mantly",
@@ -22,6 +22,7 @@
     "@fortawesome/fontawesome-free": "^7.3.0",
     "@popperjs/core": "^2.11.8",
     "@simpleworkjs/app-stack": "^1.0.0",
+    "@simpleworkjs/bao-conf": "^1.0.0",
     "@simpleworkjs/conf": "^1.2.0",
     "@simpleworkjs/frontend": "^0.2.7",
     "@simpleworkjs/ldap": "^1.0.0",


### PR DESCRIPTION
## What

The proxy now loads its secrets from **OpenBao** at boot via the new [`@simpleworkjs/bao-conf`](https://simpleworkjs.github.io/bao-conf/) package, instead of only from the bind-mounted `config/proxy-secrets.js`.

## Why

theta42 is consolidating all secrets into OpenBao (scoped tokens + per-app policies) so the stack has one central, policy-enforced secrets store — and so end users / external apps can be given scoped access too. This is the proxy's half of that move (companion to sso-manager-node's vault broker and jump-host's boot change).

## How
- `bin/www` defers `require('../app')` until `bao-conf.init({ path: 'proxy' })` resolves, because the OIDC `clientSecret` is captured at require time inside `createOidcClient` (during `require('../models')`, which `require('../app')` triggers transitively).
- Authenticates to OpenBao with a scoped `VAULT_TOKEN` (env, policy `proxy` — read-only on `secret/proxy/conf`), never the root token.
- **Fail-soft:** if OpenBao is unreachable, boot continues from `CONF_SECRETS` (the file config) — no hard dependency on OpenBao being up.
- `config/proxy-secrets.js` becomes an operator-edit seed artifact (gitignored); OpenBao is authoritative after first boot.
- README gains a Secrets section pointing to theta-env's [Secrets docs](https://theta42.github.io/theta-env/secrets/).

## Verification
- `npm test` green locally (206/206, 0 fail).
- `@simpleworkjs/bao-conf` published to npm @ 1.0.0; lockfile refreshed (real `resolved` entry, no `link:true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)