### PR TITLE
v1.13.1: bump @simpleworkjs/bao-conf to 1.0.1 (fix standalone boot crash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ correspond to git tags (`vX.Y.Z`) and `nodejs/package.json`'s `version`.
 
 ## [Unreleased]
 
+## [1.13.1] - 2026-08-01
+
+### Fixed
+- **Bumped `@simpleworkjs/bao-conf` to 1.0.1** so standalone/no-OpenBao boots
+  don't crash. bao-conf 1.0.0's `init()` threw when `VAULT_TOKEN` was unset,
+  which — combined with `bin/www`'s `.catch(() => process.exit(1))` — made the
+  proxy exit at boot in any deployment without an OpenBao sidecar (standalone
+  Docker, bare metal). 1.0.1 makes `init()` fail-soft on a missing token (warn
+  + continue from `CONF_SECRETS`), matching the documented contract. The
+  theta-env stack is unaffected (it always sets a scoped `VAULT_TOKEN`).
+
 ## [1.13.0] - 2026-08-01
 
 ### Changed

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proxy-api",
-  "version": "1.9.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proxy-api",
-      "version": "1.9.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",
@@ -299,9 +299,9 @@
       }
     },
     "node_modules/@simpleworkjs/bao-conf": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@simpleworkjs/bao-conf/-/bao-conf-1.0.0.tgz",
-      "integrity": "sha512-HxB2ohFuDKbwTfNh5dXCot0dd6qoP+3Ebz1xKH0eOhKNVNMjHU1p7XZv2VTe+VnHn+DV22Eh8lAgWxnX/pkXUw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@simpleworkjs/bao-conf/-/bao-conf-1.0.1.tgz",
+      "integrity": "sha512-mcay5NQ/w9ShpIAolMP/3f9TfXSLE+d5jrA4dTPOUHDjTkdsP7pe4hMmQUmwnniR59U1bGoRIVdXjvDbX3I5nw==",
       "license": "MIT",
       "dependencies": {
         "extend": "^3.0.2"

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-api",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "author": [
     {
       "name": "William Mantly",


### PR DESCRIPTION
## What
Patch bump of `@simpleworkjs/bao-conf` 1.0.0 → 1.0.1.

## Why
bao-conf 1.0.0's `init()` threw when `VAULT_TOKEN` was unset. Combined with `bin/www`'s `.catch(() => process.exit(1))` (from v1.13.0), this made the proxy **exit at boot in any deployment without an OpenBao sidecar** — standalone Docker, bare metal. 1.0.1 makes `init()` fail-soft on a missing token (warn + continue from `CONF_SECRETS`), matching the documented contract.

The theta-env stack is unaffected — `setup.sh` always mints and sets a scoped `VAULT_TOKEN`.

## Verification
- `npm test` green locally (206/206).
- bao-conf 1.0.1 published; the sso all-in-one image (same `bin/www` + `bao-conf.init` pattern) boots healthy with no `VAULT_TOKEN` (`/health` → `{"status":"ok"}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)