### PR TITLE
chore: bump package.json version to 1.14.3

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-api",
-  "version": "1.13.3",
+  "version": "1.14.3",
   "author": [
     {
       "name": "William Mantly",


### PR DESCRIPTION
Bumps package.json version string to match release v1.14.3.