### PR TITLE
feat(proxy): remove standalone users UI/nav, refactor permissions to list view with live reload, and add dynamic reload to groups v1.32.0

### DIFF
--- a/nodejs/routes/render.js
+++ b/nodejs/routes/render.js
@@ -55,7 +55,7 @@ router.get('/dns', async function(req, res, next) {
 
 
 router.get('/users', async function(req, res, next) {
-  res.render('users', {...values});
+  res.redirect(301, '/hosts');
 });
 
 router.get('/permissions', async function(req, res, next) {

--- a/nodejs/utils/ui.js
+++ b/nodejs/utils/ui.js
@@ -38,7 +38,6 @@ module.exports = {
 	nav: [
 		{href: '/hosts', icon: 'fa-solid fa-network-wired', label: 'Hosts', groups: []},
 		{href: '/dns', icon: 'fa-solid fa-record-vinyl', label: 'DNS', groups: []},
-		{href: '/users', icon: 'fa-solid fa-users', label: 'Users', groups: ['admin']},
 		{href: '/permissions', icon: 'fa-solid fa-user-shield', label: 'Permissions', groups: ['admin']},
 		{href: '/groups', icon: 'fa-solid fa-users-gear', label: 'Groups', groups: ['admin']},
 	],

--- a/nodejs/views/groups.ejs
+++ b/nodejs/views/groups.ejs
@@ -16,6 +16,14 @@
 
 <script type="text/javascript">
 
+	function loadGroups() {
+		app.group.list(function(error, data){
+			if(error) return app.messages.action(error, $('#groups-list'), 'danger');
+			$.scope.LocalGroup.empty();
+			for(let g of (data.results || [])) $.scope.LocalGroup.push(g);
+		});
+	}
+
 	// Usernames for the "add member" autocomplete (reuses the permission
 	// subjects endpoint, which is admin-only like this page).
 	function loadUserSuggestions(){
@@ -28,15 +36,16 @@
 
 	function removeGroup(name){
 		app.group.remove(name, function(error, data){
-			if(error) return app.messages.action(error, $.scope.LocalGroup.$this, 'danger');
+			if(error) return app.messages.action(error, $('#groups-list'), 'danger');
 			$.scope.LocalGroup.remove(name);
+			loadGroups();
 		});
 	}
 
 	function removeMember(group, username){
 		app.group.removeMember(group, username, function(error, data){
-			if(error) return app.messages.action(error, $.scope.LocalGroup.$this, 'danger');
-			// websocket update echoes the new member list.
+			if(error) return app.messages.action(error, $('#groups-list'), 'danger');
+			loadGroups();
 		});
 	}
 
@@ -47,17 +56,14 @@
 		let username = ($input.val() || '').trim();
 		if(!username) return;
 		app.group.addMember(group, username, function(error, data){
-			if(error) return app.messages.action(error, $.scope.LocalGroup.$this, 'danger');
+			if(error) return app.messages.action(error, $('#groups-list'), 'danger');
 			$input.val('');
+			loadGroups();
 		});
 	}
 
 	$(document).ready(function(){
-		app.group.list(function(error, data){
-			if(error) return app.messages.action(error, $.scope.LocalGroup.$this, 'danger');
-			for(let g of data.results) $.scope.LocalGroup.push(g);
-		});
-
+		loadGroups();
 		loadUserSuggestions();
 
 		$.scope.LocalGroup.__take = function($el){
@@ -66,14 +72,13 @@
 		};
 
 		app.subscribe(/^model:LocalGroup:create/, function(data){
-			$.scope.LocalGroup.remove(data.name);
-			$.scope.LocalGroup.unshift(data);
+			loadGroups();
 		});
 		app.subscribe(/^model:LocalGroup:update/, function(data, topic){
-			$.scope.LocalGroup.update(topic.split(':')[3], data);
+			loadGroups();
 		});
 		app.subscribe(/^model:LocalGroup:remove/, function(data, topic){
-			$.scope.LocalGroup.remove(topic.split(':')[3]);
+			loadGroups();
 		});
 	});
 </script>
@@ -81,61 +86,59 @@
 <div class="container mt-4">
 <datalist id="groupUsers"></datalist>
 
-<div class="row" style="display:none">
-	<div class="col-md-4">
-		<div class="card shadow-lg">
-			<div class="card-header text-center">
-				<span class="card-icon float-start"><i class="fa-solid fa-users-gear"></i></span>
-				<span class="card-title">Add Group</span>
-				<a href="/docs/access" class="text-reset float-end" title="Help"><i class="fa-solid fa-circle-question"></i></a>
+<div class="row">
+	<div class="col-md-4 mb-4">
+		<div class="card shadow">
+			<div class="card-header d-flex justify-content-between align-items-center">
+				<div><i class="fa-solid fa-users-gear me-2"></i><strong>Add Group</strong></div>
+				<a href="/docs/access" class="text-reset" title="Help"><i class="fa-solid fa-circle-question"></i></a>
 			</div>
 			<div class="card-header actionMessage" style="display:none"></div>
 			<div class="card-body">
-				<form action="group/" onsubmit="formAJAX(this)">
-					<div class="form-group">
-						<label class="control-label">Group name</label>
-						<input type="text" class="form-control" name="name" placeholder="dns-team" autocomplete="off" />
-						<div class="text-muted" style="font-size:.8rem">
-							Lowercased to a slug. Use the name as a Subject (type "group")
-							on the Permissions page.
+				<form action="group/" onsubmit="formAJAX(this)" evalAJAX="loadGroups(); this.reset();">
+					<div class="mb-3">
+						<label class="form-label fw-bold">Group name</label>
+						<input type="text" class="form-control" name="name" placeholder="dns-team" autocomplete="off" required />
+						<div class="form-text">
+							Lowercased to a slug. Use the name as a Subject (type "group") on the Permissions page.
 						</div>
 					</div>
 					<hr />
-					<button type="submit" class="btn btn-info">Add Group</button>
+					<button type="submit" class="btn btn-primary w-100"><i class="fa-solid fa-plus me-1"></i> Add Group</button>
 				</form>
 			</div>
 		</div>
 	</div>
 
-	<div class="col-md-8">
-		<div class="row row-cols-1 g-3">
+	<div class="col-md-8 mb-4">
+		<div class="row row-cols-1 g-3" id="groups-list">
 			<div jq-repeat="LocalGroup" jq-repeat-index="name" style="display:none" class="col">
-				<div class="card shadow-lg">
+				<div class="card shadow-sm border">
 					<div class="card-header d-flex align-items-center">
-						<span class="card-icon me-2"><i class="fa-solid fa-users"></i></span>
-						<span class="card-title">{{ name }}</span>
-						<span class="badge text-bg-secondary ms-2">{{ memberCount }} member(s)</span>
+						<span class="card-icon me-2"><i class="fa-solid fa-users text-primary"></i></span>
+						<strong class="me-2">{{ name }}</strong>
+						<span class="badge text-bg-secondary">{{ memberCount }} member(s)</span>
 						<button type="button" class="btn btn-sm btn-outline-danger ms-auto" onclick="removeGroup('{{name}}')">
 							<i class="fa-solid fa-trash"></i>
 						</button>
 					</div>
 					<div class="card-body">
-						<div class="mb-2">
+						<div class="mb-3">
 							{{#memberList}}
 							<span class="badge text-bg-info member-pill me-1 mb-1 fs-6">
 								{{ username }}
-								<i class="fa-solid fa-xmark ms-1" onclick="removeMember('{{group}}','{{username}}')"></i>
+								<i class="fa-solid fa-xmark ms-1 text-danger" onclick="removeMember('{{group}}','{{username}}')"></i>
 							</span>
 							{{/memberList}}
 							{{^memberList}}
-							<span class="text-muted">No members yet.</span>
+							<span class="text-muted small">No members yet.</span>
 							{{/memberList}}
 						</div>
-						<div class="input-group member-add" data-group="{{name}}">
-							<input type="text" class="form-control" list="groupUsers" placeholder="username" autocomplete="off"
+						<div class="input-group input-group-sm member-add" data-group="{{name}}">
+							<input type="text" class="form-control" list="groupUsers" placeholder="Add username..." autocomplete="off"
 								onkeydown="if(event.key==='Enter'){event.preventDefault();addMember(this.nextElementSibling);}" />
 							<button type="button" class="btn btn-success" onclick="addMember(this)">
-								<i class="fa-solid fa-user-plus"></i> Add
+								<i class="fa-solid fa-user-plus me-1"></i> Add
 							</button>
 						</div>
 					</div>

--- a/nodejs/views/permissions.ejs
+++ b/nodejs/views/permissions.ejs
@@ -4,20 +4,15 @@
 	app.auth.forceLogin();
 </script>
 
-<style type="text/css">
-	label.control-label{
-		font-weight: bold;
-		margin-bottom: 1px;
-	}
-	.card-title{
-		font-weight: bold;
-	}
-	.field-hint{
-		font-size: .8rem;
-	}
-</style>
-
 <script type="text/javascript">
+
+	function loadPermissions() {
+		app.permission.list(function(error, data){
+			if(error) return app.messages.action(error, $('#permissions-list'), 'danger');
+			$.scope.Permission.empty();
+			for(let p of (data.results || [])) $.scope.Permission.push(p);
+		});
+	}
 
 	// Fill the username/group datalists that back the Subject autocomplete.
 	function loadSubjectSuggestions(){
@@ -42,63 +37,61 @@
 
 	function permissionAddOpen(){
 		app.modal.open({title: 'Add Permission', bodyHtml:
-			'<form action="permission/" onsubmit="formAJAX(this)" evalAJAX="app.modal.close();">'
-			+   '<div class="form-group">'
-			+     '<label class="control-label">Subject type</label>'
-			+     '<select class="form-control" name="subjectType" onchange="subjectTypeChanged(this)">'
+			'<form action="permission/" onsubmit="formAJAX(this)" evalAJAX="app.modal.close(); loadPermissions();">'
+			+   '<div class="mb-3">'
+			+     '<label class="form-label fw-bold">Subject type</label>'
+			+     '<select class="form-select" name="subjectType" onchange="subjectTypeChanged(this)">'
 			+       '<option value="user">User</option>'
 			+       '<option value="group">Group</option>'
 			+     '</select>'
 			+   '</div>'
-			+   '<div class="form-group">'
-			+     '<label class="control-label">Subject (username or group)</label>'
+			+   '<div class="mb-3">'
+			+     '<label class="form-label fw-bold">Subject (username or group)</label>'
 			+     '<input type="text" class="form-control" name="subject" list="subjectUsers" placeholder="alice" autocomplete="off" />'
 			+   '</div>'
-			+   '<div class="form-group">'
-			+     '<label class="control-label">Scope</label>'
-			+     '<select class="form-control" name="scope">'
+			+   '<div class="mb-3">'
+			+     '<label class="form-label fw-bold">Scope</label>'
+			+     '<select class="form-select" name="scope">'
 			+       '<option value="domain">Domain</option>'
 			+       '<option value="global">Global</option>'
 			+     '</select>'
 			+   '</div>'
-			+   '<div class="form-group">'
-			+     '<label class="control-label">Domain (for domain scope)</label>'
+			+   '<div class="mb-3">'
+			+     '<label class="form-label fw-bold">Domain (for domain scope)</label>'
 			+     '<input type="text" class="form-control" name="domain" placeholder="example.com" autocomplete="off" />'
-			+     '<div class="field-hint text-muted">'
+			+     '<div class="form-text text-muted">'
 			+       'Wildcards: <code>*.example.com</code> matches one label, '
 			+       '<code>**.example.com</code> matches any depth (incl. the apex), '
 			+       '<code>**</code> matches every domain.'
 			+     '</div>'
 			+   '</div>'
-			+   '<div class="form-group">'
-			+     '<label class="control-label">Role</label>'
-			+     '<select class="form-control" name="role">'
+			+   '<div class="mb-3">'
+			+     '<label class="form-label fw-bold">Role</label>'
+			+     '<select class="form-select" name="role">'
 			+       '<option value="viewer">Viewer (read)</option>'
 			+       '<option value="manager">Manager (full over domain)</option>'
 			+       '<option value="admin">Admin (global only)</option>'
 			+     '</select>'
 			+   '</div>'
 			+   '<hr />'
-			+   '<button type="submit" class="btn btn-info">Add Permission</button>'
+			+   '<div class="d-flex justify-content-end gap-2">'
+			+     '<button type="button" class="btn btn-secondary" onclick="app.modal.close()">Cancel</button>'
+			+     '<button type="submit" class="btn btn-primary">Add Permission</button>'
+			+   '</div>'
 			+ '</form>',
 		});
 	}
 
 	function removePermission(id){
 		app.permission.remove(id, function(error, data){
-			if(error) return app.messages.action(error, $.scope.Permission.$this, 'danger');
-			// The websocket echo removes the row; drop it locally too for snappiness.
+			if(error) return app.messages.action(error, $('#permissions-list'), 'danger');
 			$.scope.Permission.remove(id);
+			loadPermissions();
 		});
 	}
 
 	$(document).ready(function(){
-		// Existing permissions.
-		app.permission.list(function(error, data){
-			if(error) return app.messages.action(error, $.scope.Permission.$this, 'danger');
-			for(let p of data.results) $.scope.Permission.push(p);
-		});
-
+		loadPermissions();
 		loadSubjectSuggestions();
 
 		$.scope.Permission.__take = function($el, item, list){
@@ -108,12 +101,10 @@
 
 		// Live updates (model:Permission:*), so adds/removes reflect for everyone.
 		app.subscribe(/^model:Permission:create/, function(data){
-			$.scope.Permission.remove(data.id);
-			$.scope.Permission.unshift(data);
-			setTimeout(function(){ app.util.revealItem($('#permission-row-' + data.id)); }, 100);
+			loadPermissions();
 		});
 		app.subscribe(/^model:Permission:remove/, function(data, topic){
-			$.scope.Permission.remove(topic.split(':')[3]);
+			loadPermissions();
 		});
 	});
 </script>
@@ -122,47 +113,48 @@
 <datalist id="subjectUsers"></datalist>
 <datalist id="subjectGroups"></datalist>
 
-<div class="row" style="display:none">
+<div class="row">
 	<div class="col-12">
-		<div class="card shadow-lg">
+		<div class="card shadow">
 
-			<div class="card-header text-center">
-				<span class="card-icon float-start">
-					<i class="fa-solid fa-list-check"></i>
-				</span>
-				<span class="card-title">Permissions</span>
-				<span class="float-end">
-					<a href="/docs/access" class="text-reset me-2" title="Help"><i class="fa-solid fa-circle-question"></i></a>
-					<button type="button" class="btn btn-sm btn-success" onclick="permissionAddOpen()">
-						<i class="fa-solid fa-user-shield"></i>
-						Add Permission
+			<div class="card-header d-flex justify-content-between align-items-center">
+				<div>
+					<i class="fa-solid fa-user-shield me-2"></i><strong>Permissions List</strong>
+				</div>
+				<div>
+					<a href="/docs/access" class="text-reset me-3" title="Help"><i class="fa-solid fa-circle-question"></i></a>
+					<button type="button" class="btn btn-sm btn-primary" onclick="permissionAddOpen()">
+						<i class="fa-solid fa-user-shield me-1"></i> Add Permission
 					</button>
-				</span>
+				</div>
 			</div>
 
 			<div class="card-header actionMessage" style="display:none"></div>
-			<div class="card-body">
-			<div class="row row-cols-1 row-cols-lg-2 g-3" id="permission-cards">
-				<div class="col" jq-repeat="Permission" jq-repeat-index="id" id="permission-row-{{id}}" style="display:none">
-					<div class="card shadow-sm h-100">
-						<div class="card-body">
-							<h6 class="mb-2">
-								<span class="badge text-bg-secondary">{{ subjectType }}</span>
-								{{ subject }}
-							</h6>
-							<dl class="row mb-2 small">
-								<dt class="col-4">Scope</dt><dd class="col-8">{{ scope }}</dd>
-								<dt class="col-4">Domain</dt><dd class="col-8">{{ domain }}</dd>
-								<dt class="col-4">Role</dt><dd class="col-8">{{ role }}</dd>
-							</dl>
-							<button type="button" class="btn btn-sm btn-danger" onclick="removePermission('{{id}}')">
-								<i class="fa-solid fa-trash"></i>
-								Delete
+			<div class="card-body p-0">
+				<ul class="list-group list-group-flush" id="permissions-list">
+					<li class="list-group-item d-flex align-items-center justify-content-between py-3" jq-repeat="Permission" jq-repeat-index="id" id="permission-row-{{id}}" style="display:none">
+						<div class="d-flex align-items-center">
+							<div class="me-3 fs-4 text-primary">
+								<i class="fa-solid fa-user-check"></i>
+							</div>
+							<div>
+								<h6 class="mb-1 fw-bold">
+									<span class="badge bg-secondary me-2">{{ subjectType }}</span> {{ subject }}
+								</h6>
+								<div class="small text-muted">
+									<span class="me-3"><strong>Scope:</strong> {{ scope }}</span>
+									<span class="me-3"><strong>Domain:</strong> <code>{{ domain }}</code></span>
+									<span><strong>Role:</strong> <span class="badge bg-info text-dark">{{ role }}</span></span>
+								</div>
+							</div>
+						</div>
+						<div>
+							<button type="button" class="btn btn-sm btn-outline-danger" onclick="removePermission('{{id}}')">
+								<i class="fa-solid fa-trash me-1"></i> Delete
 							</button>
 						</div>
-					</div>
-				</div>
-			</div>
+					</li>
+				</ul>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Removes standalone users UI/route, updates permissions to single-column list view with dynamic auto-refresh, and adds auto-reload to groups view.