### PR TITLE
fix: sync package version to v1.32.0 tag

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proxy-api",
-  "version": "1.13.3",
+  "version": "1.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proxy-api",
-      "version": "1.13.3",
+      "version": "1.32.0",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-api",
-  "version": "1.14.3",
+  "version": "1.32.0",
   "author": [
     {
       "name": "William Mantly",


### PR DESCRIPTION
The v1.32.0 release tag was created but nodejs/package.json was left at 1.14.3 (and the lockfile at 1.13.3), so the deployed app's buildVersion lags its own release tag and the update-check banner falsely reports a newer version available. Bump the version fields to match the tag.

Co-Authored-By: Claude <noreply@anthropic.com>